### PR TITLE
feat: Multi-emotion selection, negative emotions, rate limiting & fart button

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,23 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>my-love</title>
+    <!-- Single Page Apps for GitHub Pages - redirect handler -->
+    <script type="text/javascript">
+      // This script handles the redirect from 404.html
+      // It converts the query string back to a proper path
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search
+            .slice(1)
+            .split('&')
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
+            .join('?');
+          window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>My Love</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (see this determine for why)
+      // https://docs.microsoft.com/en-us/archive/blogs/ieinternals/friendly-http-error-pages
+      var pathSegmentsToKeep = 1; // Keep 1 path segment for GitHub Pages repos
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          '//' +
+          l.hostname +
+          (l.port ? ':' + l.port : '') +
+          l.pathname
+            .split('/')
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join('/') +
+          '/?/' +
+          l.pathname
+            .slice(1)
+            .split('/')
+            .slice(pathSegmentsToKeep)
+            .join('/')
+            .replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash
+      );
+    </script>
+  </head>
+  <body>
+    <!-- This body needs to be at least 512 bytes for IE -->
+    <!-- Padding for Internet Explorer compatibility -->
+    <!-- This 404 page redirects to the main app for SPA routing -->
+    <!-- When GitHub Pages receives a request for a path that doesn't exist, -->
+    <!-- it serves this 404.html file which then redirects to the app -->
+    <!-- The redirect preserves the original path in the query string -->
+    <!-- so the app can restore the correct route on load -->
+  </body>
+</html>

--- a/src/components/MoodHistory/CalendarDay.tsx
+++ b/src/components/MoodHistory/CalendarDay.tsx
@@ -1,18 +1,37 @@
 import { memo } from 'react';
 import { m as motion } from 'framer-motion';
-import { Heart, Smile, Meh, MessageCircle, Sparkles } from 'lucide-react';
+import {
+  Heart,
+  Smile,
+  Meh,
+  MessageCircle,
+  Sparkles,
+  Frown,
+  AlertCircle,
+  Angry,
+  UserMinus,
+  Battery,
+} from 'lucide-react';
 import type { MoodEntry, MoodType } from '../../types';
 
 /**
  * Mood icon configuration
  * Story 6.3: Task 9 - Performance optimization with React.memo
+ * Updated: Added negative emotions support
  */
 const MOOD_CONFIG = {
+  // Positive emotions
   loved: { icon: Heart, color: 'text-pink-500', bgColor: 'bg-pink-100' },
   happy: { icon: Smile, color: 'text-yellow-500', bgColor: 'bg-yellow-100' },
   content: { icon: Meh, color: 'text-blue-500', bgColor: 'bg-blue-100' },
   thoughtful: { icon: MessageCircle, color: 'text-purple-500', bgColor: 'bg-purple-100' },
   grateful: { icon: Sparkles, color: 'text-green-500', bgColor: 'bg-green-100' },
+  // Negative emotions
+  sad: { icon: Frown, color: 'text-gray-500', bgColor: 'bg-gray-100' },
+  anxious: { icon: AlertCircle, color: 'text-orange-500', bgColor: 'bg-orange-100' },
+  frustrated: { icon: Angry, color: 'text-red-500', bgColor: 'bg-red-100' },
+  lonely: { icon: UserMinus, color: 'text-indigo-500', bgColor: 'bg-indigo-100' },
+  tired: { icon: Battery, color: 'text-slate-500', bgColor: 'bg-slate-100' },
 } as const;
 
 interface CalendarDayProps {

--- a/src/components/MoodHistory/MoodDetailModal.tsx
+++ b/src/components/MoodHistory/MoodDetailModal.tsx
@@ -1,14 +1,28 @@
 import { useEffect, useRef } from 'react';
 import { m as motion, AnimatePresence } from 'framer-motion';
-import { X, Heart, Smile, Meh, MessageCircle, Sparkles } from 'lucide-react';
+import {
+  X,
+  Heart,
+  Smile,
+  Meh,
+  MessageCircle,
+  Sparkles,
+  Frown,
+  AlertCircle,
+  Angry,
+  UserMinus,
+  Battery,
+} from 'lucide-react';
 import type { MoodEntry, MoodType } from '../../types';
 import { formatModalDate, formatModalTime } from '../../utils/calendarHelpers';
 
 /**
  * Mood icon and color configuration
  * Story 6.3: AC-4 - Mood type with icon and color
+ * Updated: Added negative emotions support
  */
 const MOOD_CONFIG = {
+  // Positive emotions
   loved: { icon: Heart, color: 'text-pink-500', bgColor: 'bg-pink-100', label: 'Loved' },
   happy: { icon: Smile, color: 'text-yellow-500', bgColor: 'bg-yellow-100', label: 'Happy' },
   content: { icon: Meh, color: 'text-blue-500', bgColor: 'bg-blue-100', label: 'Content' },
@@ -24,6 +38,17 @@ const MOOD_CONFIG = {
     bgColor: 'bg-green-100',
     label: 'Grateful',
   },
+  // Negative emotions
+  sad: { icon: Frown, color: 'text-gray-500', bgColor: 'bg-gray-100', label: 'Sad' },
+  anxious: {
+    icon: AlertCircle,
+    color: 'text-orange-500',
+    bgColor: 'bg-orange-100',
+    label: 'Anxious',
+  },
+  frustrated: { icon: Angry, color: 'text-red-500', bgColor: 'bg-red-100', label: 'Frustrated' },
+  lonely: { icon: UserMinus, color: 'text-indigo-500', bgColor: 'bg-indigo-100', label: 'Lonely' },
+  tired: { icon: Battery, color: 'text-slate-500', bgColor: 'bg-slate-100', label: 'Tired' },
 } as const;
 
 interface MoodDetailModalProps {

--- a/src/components/PartnerMoodView/PartnerMoodView.tsx
+++ b/src/components/PartnerMoodView/PartnerMoodView.tsx
@@ -16,6 +16,11 @@ import {
   Check,
   X,
   Users,
+  Frown,
+  AlertCircle,
+  Angry,
+  UserMinus,
+  Battery,
 } from 'lucide-react';
 import { useAppStore } from '../../stores/useAppStore';
 import type { MoodEntry } from '../../types';
@@ -24,11 +29,18 @@ import { moodSyncService } from '../../api/moodSyncService';
 
 // Mood icon mapping (same as MoodTracker)
 const MOOD_CONFIG = {
+  // Positive emotions
   loved: { icon: Heart, label: 'Loved', color: 'text-red-500' },
   happy: { icon: Smile, label: 'Happy', color: 'text-yellow-500' },
   content: { icon: Meh, label: 'Content', color: 'text-blue-500' },
   thoughtful: { icon: MessageCircle, label: 'Thoughtful', color: 'text-purple-500' },
   grateful: { icon: Sparkles, label: 'Grateful', color: 'text-pink-500' },
+  // Negative emotions
+  sad: { icon: Frown, label: 'Sad', color: 'text-gray-500' },
+  anxious: { icon: AlertCircle, label: 'Anxious', color: 'text-orange-500' },
+  frustrated: { icon: Angry, label: 'Frustrated', color: 'text-red-600' },
+  lonely: { icon: UserMinus, label: 'Lonely', color: 'text-indigo-500' },
+  tired: { icon: Battery, label: 'Tired', color: 'text-slate-500' },
 } as const;
 
 /**

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -56,7 +56,17 @@ export type Database = {
         Row: {
           id: string;
           user_id: string;
-          mood_type: 'loved' | 'happy' | 'content' | 'thoughtful' | 'grateful';
+          mood_type:
+            | 'loved'
+            | 'happy'
+            | 'content'
+            | 'thoughtful'
+            | 'grateful'
+            | 'sad'
+            | 'anxious'
+            | 'frustrated'
+            | 'lonely'
+            | 'tired';
           note: string | null;
           created_at: string | null;
           updated_at: string | null;
@@ -64,7 +74,17 @@ export type Database = {
         Insert: {
           id?: string;
           user_id: string;
-          mood_type: 'loved' | 'happy' | 'content' | 'thoughtful' | 'grateful';
+          mood_type:
+            | 'loved'
+            | 'happy'
+            | 'content'
+            | 'thoughtful'
+            | 'grateful'
+            | 'sad'
+            | 'anxious'
+            | 'frustrated'
+            | 'lonely'
+            | 'tired';
           note?: string | null;
           created_at?: string | null;
           updated_at?: string | null;
@@ -72,7 +92,17 @@ export type Database = {
         Update: {
           id?: string;
           user_id?: string;
-          mood_type?: 'loved' | 'happy' | 'content' | 'thoughtful' | 'grateful';
+          mood_type?:
+            | 'loved'
+            | 'happy'
+            | 'content'
+            | 'thoughtful'
+            | 'grateful'
+            | 'sad'
+            | 'anxious'
+            | 'frustrated'
+            | 'lonely'
+            | 'tired';
           note?: string | null;
           created_at?: string | null;
           updated_at?: string | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,17 @@ export type ThemeName = 'sunset' | 'ocean' | 'lavender' | 'rose';
 
 export type MessageCategory = 'reason' | 'memory' | 'affirmation' | 'future' | 'custom';
 
-export type MoodType = 'loved' | 'happy' | 'content' | 'thoughtful' | 'grateful';
+export type MoodType =
+  | 'loved'
+  | 'happy'
+  | 'content'
+  | 'thoughtful'
+  | 'grateful'
+  | 'sad'
+  | 'anxious'
+  | 'frustrated'
+  | 'lonely'
+  | 'tired';
 
 export interface Message {
   id: number;
@@ -62,7 +72,8 @@ export interface Anniversary {
 export interface MoodEntry {
   id?: number; // Auto-increment (IndexedDB)
   userId: string; // Hardcoded for single-user (from constants.ts)
-  mood: MoodType;
+  mood: MoodType; // Primary mood (for backward compatibility)
+  moods?: MoodType[]; // Multiple mood support
   note?: string; // Optional, max 200 chars
   date: string; // ISO date string (YYYY-MM-DD)
   timestamp: Date; // Full timestamp when logged


### PR DESCRIPTION
## Summary
- **Fixed MoodApi validation errors** - Made timestamps nullable in Zod schemas to match PostgreSQL
- **Multi-emotion selection** - Users can now select multiple moods at once
- **Negative emotions** - Added sad, anxious, frustrated, lonely, tired
- **Rate limiting** - 30-minute cooldowns for pokes/kisses/farts
- **Fart button** - New button with animated 💩 and 💨 effects
- **GitHub Pages 404 fix** - Added SPA routing redirect for page refreshes

## Test plan
- [ ] Verify mood logging no longer shows validation errors
- [ ] Test selecting multiple emotions in Mood Tracker
- [ ] Verify negative emotions display correctly in history
- [ ] Test rate limiting on poke/kiss/fart buttons (30 min cooldown)
- [ ] Test fart button animation
- [ ] Refresh page on different routes to verify 404 fix
- [ ] Update unit tests for rate limiting changes

**Note:** Some unit tests need updating to account for rate limiting feature (tests expect unlimited sends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)