### PR TITLE
fix(deps): close remaining brace-expansion alerts (1.x and 2.x lines)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5587,9 +5587,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7389,9 +7389,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10944,9 +10944,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
     "tmp": "^0.2.6",
     "flatted": "^3.4.2",
     "brace-expansion@^5.0.0": "^5.0.8",
+    "brace-expansion@^1.0.0": "^1.1.16",
+    "brace-expansion@^2.0.0": "^2.1.2",
     "@babel/core": "^7.29.6",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "lodash": "^4.18.1",


### PR DESCRIPTION
Follow-up to #215.

After #215 landed, GitHub re-scanned and filed two new advisories for `brace-expansion` on the older major lines, which the existing `brace-expansion@^5.0.0` override does not reach:

| Alert | Range | Fix |
|---|---|---|
| #83 | `< 1.1.16` | 1.1.16 |
| #84 | `>= 2.0.0, < 2.1.2` | 2.1.2 |

Both are **backported patches within their own major**, so no ESM/CJS jump is needed — I'd initially read this as requiring an eslint 10 major, which was too pessimistic. Added per-major override keys next to the existing 5.x one. The tree now resolves 1.1.16, 2.1.2 and 5.0.8 side by side.

Verified against the alert ranges: **CLOSED 2, STILL OPEN 0.** With #215 already merged, this takes the repo to **0 open Dependabot alerts and 0 open code scanning alerts**.

Local: lint exit 0, `tsc -b --force` exit 0, unit suite 895/895 (56/56 files).

One note for future readers: `npm audit` will still list `brace-expansion`. Its advisory entry uses a single coarse `<=5.0.7` range that sweeps in all of 1.x and 2.x, rather than GitHub's precise per-major ranges. 1.1.16 and 2.1.2 *are* the fixed releases for those lines, so this is npm-advisory-database coarseness, not real exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg