### PR TITLE
ci: cut test pipeline from ~20 min to ~7 min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,8 @@ jobs:
     name: Database Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint]
+    needs: [changes]
+    if: needs.changes.outputs.app == 'true'
     permissions:
       contents: read
     steps:
@@ -171,7 +172,8 @@ jobs:
     name: Backend Tests (${{ matrix.project }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint]
+    needs: [changes]
+    if: needs.changes.outputs.app == 'true'
     permissions:
       contents: read
     strategy:
@@ -207,59 +209,30 @@ jobs:
           retention-days: 7
 
   # ============================================
-  # Stage 6a: E2E P0 Gate (Fast Feedback)
-  # ============================================
-  e2e-p0:
-    name: E2E P0 Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    needs: [lint]
-    env:
-      CI: 'true'
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Setup Playwright E2E
-        uses: ./.github/actions/setup-playwright-e2e
-
-      - name: Run P0 tests
-        run: npx playwright test tests/e2e --project=chromium --grep "\[P0\]"
-
-      - name: Stop Supabase
-        if: always()
-        run: supabase stop --no-backup
-
-      - name: Upload P0 results
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: e2e-p0-results
-          path: |
-            test-results/
-            playwright-report/
-          retention-days: 7
-
-  # ============================================
-  # Stage 6b: E2E Full (Sharded, chromium only)
+  # Stage 6: E2E Full (Sharded, chromium only)
+  #
+  # There was previously an "E2E P0 Gate" job running `--grep "[P0]"` ahead of
+  # this one, with e2e-tests gated on it via `needs`. The shards below run the
+  # full chromium suite, which already includes every [P0] test, so the gate
+  # added ~6.4 min of serial duplicate work to every green run and only paid
+  # off when a P0 test failed. Removed; coverage is unchanged.
   # ============================================
   e2e-tests:
-    name: E2E (Shard ${{ matrix.shard }}/2)
+    name: E2E (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-    needs: [e2e-p0]
+    needs: [changes]
+    if: needs.changes.outputs.app == 'true'
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        # 4 shards, not 2. Playwright splits by test count, but the suite is
+        # duration-skewed: at 2 shards both got 55 tests yet ran 5.4 min vs
+        # 9.6 min. Per-shard provisioning is a fixed ~2.5 min floor, so 4 is
+        # where the split stops paying for itself.
+        shard: [1, 2, 3, 4]
     env:
       CI: 'true'
     steps:
@@ -273,8 +246,8 @@ jobs:
       - name: Setup Playwright E2E
         uses: ./.github/actions/setup-playwright-e2e
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/2)
-        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/2
+      - name: Run E2E tests (shard ${{ matrix.shard }}/4)
+        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/4
 
       - name: Stop Supabase
         if: always()
@@ -293,6 +266,10 @@ jobs:
   # ============================================
   # Stage 7: Burn-In (Flaky Detection)
   # Only on PRs to main — runs changed E2E specs 5x
+  #
+  # Runs alongside e2e-tests rather than after it. Burn-in re-runs the changed
+  # specs from scratch 5x, so it never consumed anything the shards produced —
+  # waiting on them just added the slowest shard to the critical path.
   # ============================================
   burn-in:
     name: Burn-In (Flaky Detection)
@@ -300,8 +277,11 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    needs: [e2e-tests]
+    needs: [changes]
+    if: >-
+      needs.changes.outputs.app == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'main'
     env:
       CI: 'true'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,69 @@ permissions:
 
 jobs:
   # ============================================
+  # Stage 0: Change detection
+  # Documentation-only PRs skip the app test stages. Deliberately keyed on
+  # "can this change affect the app", NOT on "did test files change" — tests
+  # exist to validate source changes, so gating them on test-file edits would
+  # leave every source and dependency PR untested.
+  # ============================================
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect app-affecting changes
+        id: filter
+        run: |
+          set -euo pipefail
+
+          # Only pull_request events have a base to diff against. Pushes to main,
+          # the weekly cron and manual dispatches always run the full suite.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "Event is ${{ github.event_name }} — running full suite"
+            exit 0
+          fi
+
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Fail safe: an empty diff runs everything rather than nothing.
+          if [[ -z "$CHANGED" ]]; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "Empty diff — running full suite"
+            exit 0
+          fi
+
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '(^docs/|^_bmad-output/|\.md$)' || true)
+          if [[ -z "$NON_DOCS" ]]; then
+            echo "app=false" >> "$GITHUB_OUTPUT"
+            echo "Documentation-only change — app test stages will be skipped"
+          else
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "App-affecting files changed:"
+            echo "$NON_DOCS"
+          fi
+
+  # ============================================
   # Stage 1: Lint, Type Check
   # ============================================
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: [changes]
+    if: needs.changes.outputs.app == 'true'
     permissions:
       contents: read
     steps:
@@ -52,6 +109,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [changes]
+    if: needs.changes.outputs.app == 'true'
     permissions:
       contents: read
     steps:
@@ -250,14 +309,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Setup Playwright E2E
-        uses: ./.github/actions/setup-playwright-e2e
-
+      # Detect BEFORE provisioning. Setup Playwright E2E costs ~2.5 minutes
+      # (deps + browsers + local Supabase) and used to run ahead of this check,
+      # so every PR that touched no E2E spec paid for a job that then skipped.
       - name: Detect changed E2E test files
         id: changed-tests
         run: |
@@ -266,6 +320,20 @@ jobs:
           echo "specs<<EOF" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Skip burn-in (no E2E test changes)
+        if: steps.changed-tests.outputs.specs == ''
+        run: echo "No E2E test files changed — burn-in skipped"
+
+      - uses: actions/setup-node@v6
+        if: steps.changed-tests.outputs.specs != ''
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Setup Playwright E2E
+        if: steps.changed-tests.outputs.specs != ''
+        uses: ./.github/actions/setup-playwright-e2e
 
       - name: Run burn-in (5 iterations)
         if: steps.changed-tests.outputs.specs != ''
@@ -279,16 +347,12 @@ jobs:
           done
           echo "Burn-in passed: 5/5 stable"
 
-      - name: Skip burn-in (no E2E test changes)
-        if: steps.changed-tests.outputs.specs == ''
-        run: echo "No E2E test files changed — burn-in skipped"
-
       - name: Stop Supabase
-        if: always()
+        if: always() && steps.changed-tests.outputs.specs != ''
         run: supabase stop --no-backup
 
       - name: Upload burn-in failures
-        if: failure()
+        if: failure() && steps.changed-tests.outputs.specs != ''
         uses: actions/upload-artifact@v7
         with:
           name: burn-in-failures
@@ -306,7 +370,7 @@ jobs:
     permissions:
       contents: read
     needs: [e2e-tests]
-    if: always() && needs.e2e-tests.result != 'cancelled'
+    if: always() && needs.e2e-tests.result != 'cancelled' && needs.e2e-tests.result != 'skipped'
     steps:
       - uses: actions/checkout@v6
 
@@ -349,11 +413,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [lint, unit-tests, db-tests, backend-tests, e2e-tests, burn-in]
+    needs: [changes, lint, unit-tests, db-tests, backend-tests, e2e-tests, burn-in]
     if: always()
     steps:
       - name: Evaluate results
         run: |
+          # This job is the sole required status check, so it must always report.
+          # Never skip it via paths-ignore: a required check that never runs is
+          # treated as pending, and the PR stays blocked forever.
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "Change detection did not succeed — cannot verify what to run"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.app }}" != "true" ]]; then
+            echo "Documentation-only change — app test stages skipped"
+            exit 0
+          fi
+
           echo "Lint:              ${{ needs.lint.result }}"
           echo "Unit Tests:        ${{ needs.unit-tests.result }}"
           echo "DB Tests:          ${{ needs.db-tests.result }}"


### PR DESCRIPTION
Applies every wall-clock win available without reducing coverage. **Nothing tested before is untested now.**

## The pipeline was a four-stage serial chain

```
Lint 0.8m → E2E P0 Gate 6.4m → Shard 2/2 9.6m → Burn-In 2.9m  ≈ 20 min
```

Every job now fans out in parallel from a change-detection job, so the critical path is the slowest *single* job instead of a chain.

## Changes

**1. Burn-in provisioned before checking whether it had work.** From run `30162286951`:

```
141s  success   Setup Playwright E2E     ← deps + browsers + local Supabase
  0s  success   Detect changed E2E test files
  0s  skipped   Run burn-in (5 iterations)
```

Detection now runs first, with setup gated on it. It also no longer waits on `e2e-tests` — burn-in re-runs the changed specs from scratch 5x and never consumed shard output, so that dependency only added the slowest shard to the critical path.

**2. Removed the E2E P0 Gate.** It ran `--grep "[P0]"`; the shards then re-ran those exact tests as part of the full chromium suite, gated behind it via `needs`. Pure serial duplicate work — it only paid off when a P0 test failed.

**3. 2 shards → 4.** Playwright splits by test count, but the suite is duration-skewed: both shards got 55 of 110 tests yet ran 5.4m vs 9.6m. Per-shard provisioning is a fixed ~2.5m floor, so 4 is where splitting stops paying for itself.

**4. Docs-only PRs skip the app test stages.**

### Why not "only run tests when test files change"

That inverts what CI is for. Tests validate **source** changes, so gating them on test-file edits leaves every source and dependency PR untested. Concretely: the run that caught the `loadSession` together-mode bug was `b222323`, which changed **only workflow YAML** — no source, no tests. Under that rule it never runs and the bug ships.

The filter is keyed on *"can this change affect the app"* and verified against 11 cases; it runs the full suite whenever it is not certain:

| Changed files | Result |
|---|---|
| `src/stores/slices/scriptureReadingSlice.ts` | **run** |
| `.github/workflows/test.yml` | **run** |
| `package.json` + `package-lock.json` | **run** |
| `docs/a.md` + `src/App.tsx` (mixed) | **run** |
| empty diff | **run** |
| push to main / cron / manual dispatch | **run** |
| `docs/deployment.md`, `README.md` | skip |

## Required-check safety

`Test Summary` is the sole required status check with strict mode. It is **not** excluded via `paths-ignore` — a required check that never runs reads as *pending* and would block PRs permanently. It always runs, passes explicitly for docs-only changes, and fails if change detection itself did not succeed.

## Trade-off

A lint or P0 failure no longer short-circuits the expensive jobs, so a *failing* run burns more runner minutes than before. Wall-clock was the priority.

## Expected

| | Before | After |
|---|---|---|
| App PR | ~20 min | ~7 min |
| Docs PR | ~20 min | under 1 min |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg