### PR TITLE
chore(ci): move Claude Code actions to Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,5 +77,5 @@ jobs:
             - Documentation suggestions unless a public API changed
 
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-6'
+          claude_args: '--model claude-opus-5'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/docs/development-guide/deployment.md
+++ b/docs/development-guide/deployment.md
@@ -76,7 +76,7 @@ All workflows are in `.github/workflows/`:
 
 | Workflow             | File                       | Trigger                                                    | Purpose                                                       |
 | -------------------- | -------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
-| Claude Code          | `claude.yml`               | `@claude` mentions in issues/PRs/reviews                   | Claude Code AI assistance (model: claude-opus-4-6)            |
+| Claude Code          | `claude.yml`               | `@claude` mentions in issues/PRs/reviews                   | Claude Code AI assistance (model: claude-opus-5)              |
 | Claude Code Review   | `claude-code-review.yml`   | PR opened/synchronized/ready (non-draft)                   | Automated PR code review with Claude `/review` skill          |
 
 ### Security and Quality

--- a/docs/development-guide/project-structure.md
+++ b/docs/development-guide/project-structure.md
@@ -262,7 +262,7 @@ scripts/
     supabase-migrations.yml         # Migration validation on PRs touching supabase/ paths
 
     # AI: Claude
-    claude.yml                      # Claude Code for @claude mentions in issues/PRs (claude-opus-4-6)
+    claude.yml                      # Claude Code for @claude mentions in issues/PRs (claude-opus-5)
     claude-code-review.yml          # Automated PR code review with Claude /review skill
 
     # Quality and security


### PR DESCRIPTION
Both `claude-code-action` workflows pinned `claude-opus-4-6` via `claude_args`:

| Workflow | Trigger |
|---|---|
| `claude.yml` | `@claude` mentions in issues/PRs |
| `claude-code-review.yml` | automated PR review |

Now `claude-opus-5`.

The model ID is the bare alias — `claude-opus-5`, with **no date suffix**. Appending one (`claude-opus-5-2026…`) returns a 404.

Also updates the two docs that named the old model in a workflow description (`deployment.md`, `project-structure.md`); the sweep found no other references.

Both workflow files re-validated as parseable YAML after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg