### PR TITLE
ci(codeql): scan actions and python alongside javascript-typescript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,20 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze (javascript-typescript)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # GitHub's default setup scanned `actions` and `python` once, on
+        # 2026-02-23. This workflow (advanced setup) only ever scanned
+        # javascript-typescript, so those two languages were never rescanned and
+        # their results went stale — "CodeQL last scanned this code Feb 23, 2026".
+        # Scanning them here refreshes both instead of deleting the analyses,
+        # and `actions` covers the workflows themselves (script injection,
+        # unpinned refs, over-broad permissions).
+        language: [javascript-typescript, actions, python]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,11 +41,17 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      # No autobuild step: all three languages here are no-build for CodeQL.
+      # It was a no-op for javascript-typescript and is equally unnecessary for
+      # actions and python. Compiled languages (java, go, c#, …) would need it.
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          # Required once this is a matrix: without distinct categories the
+          # three analyses overwrite each other on the same commit. The
+          # /language:<lang> form is what GitHub already keys these results by.
+          category: '/language:${{ matrix.language }}'

--- a/docs/development-guide/deployment.md
+++ b/docs/development-guide/deployment.md
@@ -85,7 +85,7 @@ All workflows are in `.github/workflows/`:
 | ----------------- | ----------------------- | ------------------------------------------ | ------------------------------------------------------------- |
 | Bundle Size       | `bundle-size.yml`       | PRs to main/develop                        | Brotli-compressed bundle size tracking with regression alerts |
 | Lighthouse        | `lighthouse.yml`        | After Deploy workflow succeeds, manual     | Lighthouse PWA audit (2 runs, public storage)                 |
-| CodeQL            | `codeql.yml`            | Push to main, PRs, weekly Monday 10 AM UTC | JavaScript/TypeScript security analysis                       |
+| CodeQL            | `codeql.yml`            | Push to main, PRs, weekly Monday 10 AM UTC | Security analysis (javascript-typescript, actions, python)    |
 | Dependency Review | `dependency-review.yml` | PRs to main/develop                        | Dependency vulnerability scanning (fails on moderate+)        |
 
 ### Composite Actions

--- a/docs/development-guide/project-structure.md
+++ b/docs/development-guide/project-structure.md
@@ -268,7 +268,7 @@ scripts/
     # Quality and security
     bundle-size.yml                 # Bundle size tracking and regression detection (brotli)
     lighthouse.yml                  # Lighthouse PWA performance audit
-    codeql.yml                      # CodeQL security analysis (javascript-typescript)
+    codeql.yml                      # CodeQL security analysis (javascript-typescript, actions, python)
     dependency-review.yml           # Dependency vulnerability scanning (fails on moderate+)
 
   codeql/


### PR DESCRIPTION
Clears the two stale-results warnings:

> `language:actions` — CodeQL last scanned this code Feb 23, 2026
> `language:python` — CodeQL last scanned this code Feb 23, 2026

## Cause

GitHub's CodeQL **default setup** scanned this repo once, on 2026-02-23, across every language it detected. The default-setup config still reports what it found:

```json
{ "state": "not-configured",
  "languages": ["actions", "javascript", "javascript-typescript", "python", "typescript"] }
```

The repo then moved to **advanced setup** (this workflow), which has only ever scanned `javascript-typescript` — true even in its first commit, `4515a71`. So `actions` and `python` had analyses on record that were never refreshed, and GitHub flagged them as out of date.

## Why rescan rather than delete the analyses

Deleting the stale analyses would silence the warning but leave both languages uncovered. They're really present:

- **actions** — 9 workflows + 2 composite actions. The `actions` pack covers script injection, unpinned action refs, and over-broad permissions. Worth having, given how much workflow surgery this repo just went through.
- **python** — `scripts/fetch_comments.py`.

## Changes

- Matrix over `[javascript-typescript, actions, python]`, `fail-fast: false` so one language's failure doesn't mask the others
- `category: /language:<lang>` on analyze — **required** once this is a matrix, or the three analyses overwrite each other on the same commit. It's also the exact key GitHub already files these results under, so it refreshes the warned-about categories rather than creating new ones
- Dropped the `autobuild` step — all three are no-build languages for CodeQL, so it was already a no-op for `javascript-typescript`

`codeql-config.yml` needs no change: `paths-ignore`, the query suites, and the `js/xss-through-dom` filter are all language-agnostic.

Docs updated in the two places that named the language explicitly.

## Note

The first run may surface **new findings** on the two previously-unscanned languages — particularly `actions`. Those would be real results, not regressions from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg