### PR TITLE
perf(e2e): run 2 Playwright workers per shard in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -94,7 +94,21 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // CI ran strictly serial (workers: 1), which left the slowest shard as the
+  // whole pipeline's critical path: shards are balanced by test *count*
+  // (28/28/27/27) but the scripture specs sort into one contiguous block, so
+  // shard 3 took 9m against ~4m for the others.
+  //
+  // These specs are wait-bound, not CPU-bound — disconnect timeouts, realtime
+  // propagation, waitForPartnerDisconnected — so the time is mostly spent
+  // idle and parallelises nearly free. global-setup already provisions 24
+  // isolated worker pairs, so per-worker data isolation is built for this.
+  //
+  // 2, not 4: ubuntu-latest is 4 vCPU and each shard also runs the local
+  // Supabase stack plus a Vite server, so 2 workers means ~2 Chromium
+  // contexts sharing 4 cores. Higher risks starving the realtime tests into
+  // timeout-driven flakes, which would cost far more than the minutes saved.
+  workers: process.env.CI ? 2 : undefined,
 
   // Timeouts
   timeout: 60 * 1000, // Test timeout: 60s


### PR DESCRIPTION
CI ran strictly serial (`workers: 1`), so the slowest shard was the entire pipeline's critical path. Measured on run `30165096753` (9.8m total):

| Shard | Duration |
|---|---|
| 1/4 | 3.7m |
| 2/4 | 4.6m |
| **3/4** | **9.0m** |
| 4/4 | 4.3m |

## Why shard 3 is the outlier

Shards are balanced by test **count** (28/28/27/27), not duration, and Playwright distributes files in sorted order — so the entire `e2e/scripture/scripture-*` block lands in one shard:

```
6 tests  scripture-reading-4.2.spec.ts
5 tests  scripture-reflection-2.3.spec.ts
5 tests  scripture-rls-security.spec.ts
4 tests  scripture-reflection-2.2.spec.ts
3 tests  scripture-overview.spec.ts
3 tests  scripture-reconnect-4.3.spec.ts
1 test   scripture-reflection-2.2-errors.spec.ts
```

That's the slowest suite in the repo — together-mode specs driving two browser contexts through disconnect timeouts and realtime waits.

## Why workers, not more shards

More shards don't fix it: the block just moves, and each shard pays a fixed ~2.5m provisioning cost (deps + browsers + Supabase). Workers parallelise *within* a shard and share its single provisioning.

These specs are **wait-bound, not CPU-bound** — most of their time is spent idle on timeouts and realtime propagation — so they parallelise nearly free. `global-setup` already provisions 24 isolated worker pairs, so per-worker data isolation was designed for this.

## Why 2 and not 4

`ubuntu-latest` is 4 vCPU, and each shard also runs the local Supabase stack and a Vite dev server. Two workers is ~2 Chromium contexts on 4 cores. Higher risks starving the realtime specs into timeout-driven flakes, which would cost more than the minutes saved.

**Expected:** shard 3 ≈ 2.5m setup + ~3.3m tests → pipeline **9.8m → ~6.5m**.

Watch the E2E shards on this PR: if they stay green, the assumption holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg