### PR TITLE
ci(review): post one consolidated review instead of scattered comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,20 +26,30 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          # Without this, every push mints a NEW comment instead of updating the
+          # existing one — PR #223 accumulated three, one per run, and #225 showed
+          # a finished review alongside a still-running "Claude Code is working…"
+          # placeholder from the next push. Defaults to false; the action
+          # describes it as "Use just one comment to deliver issue/PR comments".
+          use_sticky_comment: true
           allowed_bots: 'claude'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            You are a code review agent. Silent by default. Only speak when something matters.
+            You are a code review agent. You always deliver exactly one comment
+            containing the complete review — never a running commentary spread
+            across several. Be terse: report what matters and nothing else.
 
             ## Before reviewing
 
             1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the full diff.
             2. Check if the diff ONLY contains lockfiles, markdown, version bumps, auto-generated files,
                or `database.types.ts`. If so, skip the review entirely and post a single comment: "No reviewable changes."
-            3. Scrape your own previous inline comments via `gh api` and check the current diff.
-               If a previously flagged issue has been addressed, resolve that comment thread.
+            3. This workflow re-runs on every push. Your comment is reused and rewritten
+               in place, so write it as a complete standalone review of the CURRENT diff —
+               not a delta against your last one. If something you previously flagged is
+               now fixed, simply drop it rather than narrating the change.
 
             ## Filter gate (2-of-4 rule)
 
@@ -60,17 +70,31 @@ jobs:
             - **React/State**: Stale closures, missing deps in useEffect, Zustand misuse
             - **API misuse**: New endpoints missing auth checks, Zod schemas not updated
 
-            ## Inline comments
+            ## Output Format
 
-            - Post comments directly at the relevant line using GitHub suggestion blocks when possible.
-            - Each comment: 1-2 sentences max. State the problem and the fix. No headers.
-            - Reviewers should be able to apply fixes with one click.
+            Post exactly ONE comment, via `gh pr comment`, containing the entire review.
+            Never post inline comments. Never split findings across several comments.
+
+            Use this structure, omitting any section that would be empty:
+
+            **Summary** — one or two sentences on what this PR changes.
+
+            **Issues Found** — problems that passed the filter gate above. For each:
+            `path/to/file.ts:42` — what is wrong, and the fix. Include a suggestion
+            block where a one-click fix is possible.
+
+            **Suggestions** — non-blocking improvements, same `file:line` format.
+
+            **Verdict** — a single line stating whether anything blocks merge.
+
+            If nothing passed the filter gate, the whole comment is the Summary plus
+            `**Verdict** — no blocking issues.`
 
             ## FORBIDDEN
 
             - Praise or compliments ("Great job!", "Nice work on this!")
             - Open-ended questions ("Have you considered...?")
-            - Emojis in inline comments
+            - Emojis
             - Style preferences (naming, formatting) — the linter handles those
             - Commenting on code outside the PR diff
             - Suggesting tests unless a bug is found that tests would catch
@@ -78,4 +102,4 @@ jobs:
 
           claude_args: |
             --model claude-opus-5
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
Two separate defects, both visible on recent PRs.

## 1. Comments accumulated, one per push

`use_sticky_comment` defaults to `false` and was never set, so **every run created a new comment** instead of updating the existing one.

- PR #223 ended up with **three** claude comments
- PR #225 showed a finished review next to a still-running "Claude Code is working…" placeholder

That second one is what looked like two different formats — it was actually two runs of the *same* workflow:

| Run | Time | State | Comment |
|---|---|---|---|
| `30165324000` | 16:17 | completed | "**Claude finished** in 2m 11s" + checklist |
| `30165719577` | 16:29 | in_progress | "Claude Code is working…" |

## 2. The prompt asked for the scattered format

It had **no output contract at all** — just an `## Inline comments` section instructing 1–2 sentence inline comments with "No headers".

Comparing against `Sallvainian/Pack-Manager`, whose copy produces the wanted format: the meaningful difference is that Pack-Manager has an explicit `## Output Format` section requiring a single structured review posted via `gh pr comment`. Ours had nothing equivalent.

## Changes

- **`use_sticky_comment: true`** — one comment, rewritten in place
- Replace `## Inline comments` with `## Output Format`: exactly one comment, structured **Summary / Issues Found / Suggestions / Verdict**, empty sections omitted
- Tell the agent its comment is reused, so each review is a complete standalone read of the current diff rather than a delta narration
- Drop `mcp__github_inline_comment__create_inline_comment` from `--allowedTools` — it contradicts a single-comment contract
- Drop the now-dead instruction to scrape and resolve prior inline threads

## Deliberately kept

The **2-of-4 filter gate** and the **FORBIDDEN** list stay. They're what keep this repo's reviews quiet, and Pack-Manager has no equivalent — porting its format shouldn't mean importing its noise level. Notably Pack-Manager asks for "Positive Feedback", which this repo explicitly forbids; that section is not adopted.

The review this PR generates is itself the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg