### PR TITLE
ci(review): deliver the review through the tracking comment, not gh pr comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,7 +45,8 @@ jobs:
 
             1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the full diff.
             2. Check if the diff ONLY contains lockfiles, markdown, version bumps, auto-generated files,
-               or `database.types.ts`. If so, skip the review entirely and post a single comment: "No reviewable changes."
+               or `database.types.ts`. If so, skip the review entirely and make your comment
+               read exactly: "No reviewable changes."
             3. This workflow re-runs on every push. Your comment is reused and rewritten
                in place, so write it as a complete standalone review of the CURRENT diff —
                not a delta against your last one. If something you previously flagged is
@@ -72,7 +73,11 @@ jobs:
 
             ## Output Format
 
-            Post exactly ONE comment, via `gh pr comment`, containing the entire review.
+            `track_progress: true` means the action already created a comment for you
+            and owns it. Deliver the ENTIRE review by updating that comment with
+            `mcp__github_comment__update_claude_comment`. Do not call `gh pr comment`
+            — that creates a second, unowned comment which `use_sticky_comment`
+            cannot dedupe, which is exactly the accumulation this setup avoids.
             Never post inline comments. Never split findings across several comments.
 
             Use this structure, omitting any section that would be empty:
@@ -102,4 +107,4 @@ jobs:
 
           claude_args: |
             --model claude-opus-5
-            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
Follow-up to #227 — **found by the review agent on #227 itself**, which is a decent sign the new format is doing its job.

## The conflict

#227 set an output contract of *"post exactly ONE comment, via `gh pr comment`"*. That contradicts `track_progress: true`: the action creates a tracking comment, **owns it**, and injects instructions to deliver everything through `mcp__github_comment__update_claude_comment` without creating new comments.

An agent following the prompt literally emits **two** comments per run — the tracking comment plus a fresh `gh pr comment` — and `use_sticky_comment` can't dedupe the second, because the action doesn't own it. Precisely the accumulation #227 set out to stop.

## Severity: latent, not active

In practice the action's injected instruction won, so #227 *did* produce a single correctly-structured comment. This was one prompt-priority change away from regressing, not a live bug.

## Verified before fixing

`mcp__github_comment__update_claude_comment` is real — it lives in `src/mcp/github-comment-server.ts` and `src/modes/tag/index.ts`, the mode `track_progress: true` forces. I didn't take the finding on faith.

## Changes

- `## Output Format` now names the tracking comment as the delivery channel, and says why `gh pr comment` is wrong *here* specifically
- Same correction to the early-exit path, which said "post a single comment: `No reviewable changes.`"
- **Remove `Bash(gh pr comment:*)` from `--allowedTools`** — a second comment is now impossible at the tool level, not merely discouraged

## Known cosmetic wart, not addressed

The sticky comment accumulates one `**Claude finished …**` header per run (PR #227's has 2). That's the action prepending its own header on each update, not something the prompt controls. Leaving it unless it becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg