### PR TITLE
fix: three Rules-of-React violations + explicit grants for the API roles

### DIFF
--- a/src/components/PartnerMoodView/PartnerMoodView.tsx
+++ b/src/components/PartnerMoodView/PartnerMoodView.tsx
@@ -104,6 +104,28 @@ export function PartnerMoodView() {
   const [searchQuery, setSearchQuery] = useState('');
   const [partnerError, setPartnerError] = useState<string | null>(null);
 
+  // Story 6.4: Task 11 - Performance optimization with useCallback
+  // Declared before the effect that calls it: it used to live further down the
+  // component, so the effect closed over it before initialization and had to
+  // suppress exhaustive-deps to stay quiet.
+  const handleRefresh = useCallback(async () => {
+    if (!syncStatus.isOnline) {
+      setError('Cannot fetch moods while offline');
+      return;
+    }
+
+    try {
+      setIsRefreshing(true);
+      setError(null);
+      await fetchPartnerMoods(30); // Fetch last 30 moods
+    } catch (err) {
+      console.error('[PartnerMoodView] Failed to fetch partner moods:', err);
+      setError('Failed to load partner moods. Please try again.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [syncStatus.isOnline, fetchPartnerMoods]);
+
   // Load partner and pending requests on mount
   useEffect(() => {
     if (syncStatus.isOnline) {
@@ -112,12 +134,15 @@ export function PartnerMoodView() {
     }
   }, [syncStatus.isOnline, loadPartner, loadPendingRequests]);
 
-  // Load partner moods only if partner is connected
+  // Load partner moods only if partner is connected.
+  // syncStatus.isOnline belongs in the dependency list: the suppressed version
+  // re-ran only when `partner` changed, so reconnecting with the same partner
+  // still showed the moods fetched before going offline.
   useEffect(() => {
     if (syncStatus.isOnline && partner) {
       handleRefresh();
     }
-  }, [partner]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [syncStatus.isOnline, partner, handleRefresh]);
 
   // Story 6.4: Task 6 & 7 - Real-time subscription with connection status (AC #4)
   useEffect(() => {
@@ -191,25 +216,6 @@ export function PartnerMoodView() {
       }
     };
   }, [syncStatus.isOnline, fetchPartnerMoods]); // Re-subscribe if online status changes
-
-  // Story 6.4: Task 11 - Performance optimization with useCallback
-  const handleRefresh = useCallback(async () => {
-    if (!syncStatus.isOnline) {
-      setError('Cannot fetch moods while offline');
-      return;
-    }
-
-    try {
-      setIsRefreshing(true);
-      setError(null);
-      await fetchPartnerMoods(30); // Fetch last 30 moods
-    } catch (err) {
-      console.error('[PartnerMoodView] Failed to fetch partner moods:', err);
-      setError('Failed to load partner moods. Please try again.');
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, [syncStatus.isOnline, fetchPartnerMoods]);
 
   // Format date for display - memoized for performance
   const formatDate = useCallback((date: string): string => {

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -113,6 +113,23 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     };
   }, [scale]);
 
+  // Measured, not computed during render. Calling calculateDragConstraints()
+  // inline in JSX read imageRef.current while rendering, and on the first render
+  // the <img> is not mounted yet — so it returned the zero box and the image
+  // could not be panned until an unrelated re-render happened to recompute it.
+  // isLoading flips in the image's onLoad handler, which is exactly when
+  // naturalWidth/naturalHeight become readable.
+  const [dragConstraints, setDragConstraints] = useState({
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  });
+
+  useEffect(() => {
+    setDragConstraints(calculateDragConstraints());
+  }, [calculateDragConstraints, currentIndex, isLoading]);
+
   // AC 6.4.11: Photo preloading
   useEffect(() => {
     if (!photos || photos.length === 0) return;
@@ -397,7 +414,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
         <div className="relative flex h-full w-full items-center justify-center p-4">
           <motion.div
             drag={scale === MIN_ZOOM ? true : scale > MIN_ZOOM}
-            dragConstraints={calculateDragConstraints()}
+            dragConstraints={dragConstraints}
             dragElastic={scale === MIN_ZOOM ? 0.2 : 0.1}
             onDragEnd={handleDragEnd}
             onClick={handleDoubleTap}

--- a/src/components/scripture-reading/hooks/useReportPhase.ts
+++ b/src/components/scripture-reading/hooks/useReportPhase.ts
@@ -167,8 +167,15 @@ export function useReportPhase({
     return false;
   }, [session, updatePhase]);
 
+  // Kept in a ref so the effects below can call the latest version without
+  // listing it as a dependency (which would re-trigger them on every render).
+  // Assigned in an effect, not during render: a render-phase ref write is not
+  // idempotent, so it misbehaves under StrictMode's double render and can tear
+  // under concurrent rendering.
   const markSessionCompleteRef = useRef(markSessionComplete);
-  markSessionCompleteRef.current = markSessionComplete;
+  useEffect(() => {
+    markSessionCompleteRef.current = markSessionComplete;
+  }, [markSessionComplete]);
 
   // Story 2.3: Handle message send
   const handleMessageSend = useCallback(

--- a/supabase/migrations/20260725170000_grant_api_roles_on_public.sql
+++ b/supabase/migrations/20260725170000_grant_api_roles_on_public.sql
@@ -1,0 +1,43 @@
+-- Grant the PostgREST API roles explicit DML on public, instead of relying on
+-- Postgres default privileges to supply it.
+--
+-- Why this exists
+-- ---------------
+-- Nothing in this repo has ever granted table privileges. Every table's grants
+-- came from the default privileges that Supabase's Postgres image installs for
+-- the `public` schema. That worked until the image changed them.
+--
+-- Supabase CLI 2.109.1 ships two default-ACL entries for `public`:
+--
+--   FOR ROLE supabase_admin  -> arwdDxtm  (full) to anon, authenticated, service_role
+--   FOR ROLE postgres        -> Dxtm      (TRUNCATE/REFERENCES/TRIGGER/MAINTAIN only)
+--
+-- Migrations run as `postgres`, so every table created by this repo picks up the
+-- second rule and lands with no SELECT/INSERT/UPDATE/DELETE for the API roles.
+-- PostgREST then answers every request with 42501 "permission denied for table
+-- users" — including requests made with the service_role key, because grants are
+-- checked before RLS and service_role's BYPASSRLS does not bypass a missing grant.
+--
+-- CI pins the CLI to 2.77.1 (.github/actions/setup-supabase), whose defaults are
+-- still generous, so this only bites a local stack on a newer CLI. Granting
+-- explicitly makes the schema self-sufficient either way.
+--
+-- Safety
+-- ------
+-- This does not widen real access. Every table in `public` has RLS enabled, and
+-- a grant is not a bypass: anon and authenticated remain confined to their
+-- policies, and a table with RLS on and no policies (claude_bot_config) stays
+-- deny-all to them. This is Supabase's normal posture — broad grants, RLS as the
+-- gate — and matches what the hosted platform already applies.
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+
+-- Cover tables created by later migrations, so this does not have to be
+-- re-applied every time the schema grows.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;


### PR DESCRIPTION
Two independent fixes, both previously deferred.

---

## 1. `supabase/migrations/…_grant_api_roles_on_public.sql`

Nothing in this repo has ever granted table privileges — every table relied on the default privileges installed by Supabase's Postgres image. That stopped being enough when the image changed them.

CLI 2.109.1 ships **two** default-ACL entries for `public`:

```
FOR ROLE supabase_admin -> arwdDxtm  (full) to anon/authenticated/service_role
FOR ROLE postgres       -> Dxtm      (TRUNCATE/REFERENCES/TRIGGER/MAINTAIN only)
```

Migrations run as `postgres`, so every table lands with **no SELECT/INSERT/UPDATE/DELETE** for the API roles. PostgREST answers `42501 permission denied for table users` — even for `service_role`, because grants are checked *before* RLS and `BYPASSRLS` doesn't substitute for a missing grant. Local E2E couldn't clear `global-setup` without a hand-applied `GRANT` after every `supabase db reset`.

CI pins the CLI to 2.77.1, whose defaults are still generous, so this only bites a local stack on a newer CLI. Granting explicitly makes the schema self-sufficient on either.

### This does not widen real access

Verified after a full `supabase db reset`:

| Check | Result |
|---|---|
| `service_role` SELECT on users | true |
| `anon` SELECT on users | true |
| RLS still enabled on **all 12** tables | true |
| `claude_bot_config` policy count | **0** — still deny-all to anon/authenticated |

A grant is not a bypass. This mirrors the hosted platform's own posture: broad grants, RLS as the gate. `ALTER DEFAULT PRIVILEGES` is included so future tables inherit rather than needing this repeated.

**Verified end to end:** `supabase db reset` applies it in order, then the scripture reconnect specs pass **3/3** against the fresh database with no manual GRANT.

---

## 2. Three Rules-of-React violations

Surfaced by `eslint-plugin-react-hooks` 7.1.1, but all three are real defects on the current 7.0.1 too.

**`useReportPhase.ts:171` — ref written during render.** `markSessionCompleteRef.current = markSessionComplete` ran in the render body. Render must be idempotent; this re-runs under StrictMode's double render and can tear under concurrent rendering. Moved into an effect. Ordering verified safe — sync effect at :176, only consumer at :293, and `useRef`'s initializer already covers first render.

**`PartnerMoodView.tsx:118` — stale refresh after reconnect.** The effect listed only `[partner]` and suppressed `exhaustive-deps`, because `handleRefresh` was declared **78 lines below** the effect closing over it. `handleRefresh` depends on `syncStatus.isOnline`, so **going offline and back online with the same partner never refetched** — the user kept seeing moods from before the drop. Moved the declaration above its use and restored the real deps. This also cleared a `preserve-manual-memoization` finding, a symptom of the same ordering problem.

**`PhotoViewer.tsx:400` — ref read during render.** `dragConstraints={calculateDragConstraints()}` read `imageRef.current` while rendering. On first render the `<img>` isn't mounted, so it returned the zero box and **the photo couldn't be panned** until an unrelated re-render recomputed it. Constraints are now measured into state, keyed on `isLoading` — which the image's own `onLoad` flips, exactly when `naturalWidth`/`naturalHeight` become readable.

### Effect on 7.1.1 findings

| Rule | Before | After |
|---|---|---|
| `refs` | 2 | **0** |
| `immutability` | 1 | **0** |
| `preserve-manual-memoization` | 1 | **0** |
| `set-state-in-effect` | 6 | 8 |
| `purity` | 2 | 2 |

`set-state-in-effect` rises because the PhotoViewer fix trades a correctness bug for an advisory — unavoidable when a value must be measured from the DOM. That rule and `purity` are already `'warn'` in `eslint.config.js:45-46`, so lint stays at **0 errors**.

Typecheck clean, **896 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg