### PR TITLE
fix: photo update honesty, regenerated types, accurate IndexedDB comments

### DIFF
--- a/src/services/dbSchema.ts
+++ b/src/services/dbSchema.ts
@@ -99,7 +99,6 @@ export interface ScriptureMessage {
  *
  * Used by:
  * - moodService.ts
- * - photoStorageService.ts
  * - customMessageService.ts
  * - BaseIndexedDBService.ts (type constraints)
  *
@@ -217,8 +216,17 @@ export function upgradeDb(
   }
 
   // v2: photos store
-  // Note: v1→v2 migration with data preservation is handled in photoStorageService
-  // because it requires async transaction access. For fresh installs or v2+, we just create the store.
+  //
+  // This upgrade is DESTRUCTIVE for a v1 database: the v1 store is dropped and
+  // recreated, losing any cached rows. The data-preserving path used to live in
+  // photoStorageService.ts (it needed async transaction access, which an
+  // upgrade callback cannot do), and that file no longer exists.
+  //
+  // Left destructive deliberately. Photos are Supabase-first — IndexedDB is a
+  // read cache, so a dropped store refills on the next fetch. A v1 database
+  // also predates the current schema by a wide margin. Restoring preservation
+  // would mean reintroducing an async migration step for a cache that costs
+  // nothing to rebuild.
   if (oldVersion < 2) {
     // Delete old v1 store if it exists (had 'blob' instead of 'imageBlob')
     if (db.objectStoreNames.contains('photos')) {

--- a/src/stores/slices/photosSlice.ts
+++ b/src/stores/slices/photosSlice.ts
@@ -176,15 +176,32 @@ export const createPhotosSlice: AppStateCreator<PhotosSlice> = (set, get, _api) 
   },
 
   /**
-   * Update a photo's metadata (caption, tags)
+   * Update a photo's caption.
+   *
+   * Caption is the only mutable column: `photos` is (id, user_id, storage_path,
+   * filename, caption, mime_type, file_size, width, height, created_at), and
+   * photoService.updatePhoto drops everything else. Anything extra passed in
+   * here — `tags`, most notably — is therefore NOT persisted, so it must not be
+   * merged into local state either.
    */
   updatePhoto: async (photoId: string, updates: Partial<SupabasePhoto>) => {
     try {
-      await photoService.updatePhoto(photoId, updates);
+      // Returns false on a rejected write or when no updatable field was
+      // supplied. Previously unchecked, so a failed save still updated the UI
+      // and the change silently disappeared on reload.
+      const persisted = await photoService.updatePhoto(photoId, updates);
 
-      // Update in state on successful update
+      if (!persisted) {
+        set({ error: 'Failed to save photo changes' });
+        return;
+      }
+
       set((state) => ({
-        photos: state.photos.map((p) => (p.id === photoId ? { ...p, ...updates } : p)),
+        photos: state.photos.map((p) =>
+          p.id === photoId
+            ? { ...p, ...(updates.caption !== undefined ? { caption: updates.caption } : {}) }
+            : p
+        ),
       }));
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Update failed';

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,668 +1,706 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   graphql_public: {
     Tables: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
+      claude_bot_config: {
+        Row: {
+          created_at: string | null
+          key: string
+          value: string
+        }
+        Insert: {
+          created_at?: string | null
+          key: string
+          value: string
+        }
+        Update: {
+          created_at?: string | null
+          key?: string
+          value?: string
+        }
+        Relationships: []
+      }
       interactions: {
         Row: {
-          created_at: string | null;
-          from_user_id: string;
-          id: string;
-          to_user_id: string;
-          type: string;
-          viewed: boolean | null;
-        };
+          created_at: string | null
+          from_user_id: string
+          id: string
+          to_user_id: string
+          type: string
+          viewed: boolean | null
+        }
         Insert: {
-          created_at?: string | null;
-          from_user_id: string;
-          id?: string;
-          to_user_id: string;
-          type: string;
-          viewed?: boolean | null;
-        };
+          created_at?: string | null
+          from_user_id: string
+          id?: string
+          to_user_id: string
+          type: string
+          viewed?: boolean | null
+        }
         Update: {
-          created_at?: string | null;
-          from_user_id?: string;
-          id?: string;
-          to_user_id?: string;
-          type?: string;
-          viewed?: boolean | null;
-        };
+          created_at?: string | null
+          from_user_id?: string
+          id?: string
+          to_user_id?: string
+          type?: string
+          viewed?: boolean | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'interactions_from_user_id_fkey';
-            columns: ['from_user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "interactions_from_user_id_fkey"
+            columns: ["from_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'interactions_to_user_id_fkey';
-            columns: ['to_user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "interactions_to_user_id_fkey"
+            columns: ["to_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       love_notes: {
         Row: {
-          content: string;
-          created_at: string;
-          from_user_id: string;
-          id: string;
-          image_url: string | null;
-          to_user_id: string;
-        };
+          content: string
+          created_at: string
+          from_user_id: string
+          id: string
+          image_url: string | null
+          to_user_id: string
+        }
         Insert: {
-          content: string;
-          created_at?: string;
-          from_user_id: string;
-          id?: string;
-          image_url?: string | null;
-          to_user_id: string;
-        };
+          content: string
+          created_at?: string
+          from_user_id: string
+          id?: string
+          image_url?: string | null
+          to_user_id: string
+        }
         Update: {
-          content?: string;
-          created_at?: string;
-          from_user_id?: string;
-          id?: string;
-          image_url?: string | null;
-          to_user_id?: string;
-        };
-        Relationships: [];
-      };
+          content?: string
+          created_at?: string
+          from_user_id?: string
+          id?: string
+          image_url?: string | null
+          to_user_id?: string
+        }
+        Relationships: []
+      }
       moods: {
         Row: {
-          created_at: string | null;
-          id: string;
-          mood_type: string;
-          mood_types: string[] | null;
-          note: string | null;
-          updated_at: string | null;
-          user_id: string;
-        };
+          created_at: string | null
+          id: string
+          mood_type: string
+          mood_types: string[] | null
+          note: string | null
+          updated_at: string | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          mood_type: string;
-          mood_types?: string[] | null;
-          note?: string | null;
-          updated_at?: string | null;
-          user_id: string;
-        };
+          created_at?: string | null
+          id?: string
+          mood_type: string
+          mood_types?: string[] | null
+          note?: string | null
+          updated_at?: string | null
+          user_id: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          mood_type?: string;
-          mood_types?: string[] | null;
-          note?: string | null;
-          updated_at?: string | null;
-          user_id?: string;
-        };
+          created_at?: string | null
+          id?: string
+          mood_type?: string
+          mood_types?: string[] | null
+          note?: string | null
+          updated_at?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'moods_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "moods_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       partner_requests: {
         Row: {
-          created_at: string;
-          from_user_id: string;
-          id: string;
-          status: string;
-          to_user_id: string;
-          updated_at: string;
-        };
+          created_at: string
+          from_user_id: string
+          id: string
+          status: string
+          to_user_id: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          from_user_id: string;
-          id?: string;
-          status?: string;
-          to_user_id: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          from_user_id: string
+          id?: string
+          status?: string
+          to_user_id: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          from_user_id?: string;
-          id?: string;
-          status?: string;
-          to_user_id?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          from_user_id?: string
+          id?: string
+          status?: string
+          to_user_id?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'partner_requests_from_user_id_fkey';
-            columns: ['from_user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "partner_requests_from_user_id_fkey"
+            columns: ["from_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'partner_requests_to_user_id_fkey';
-            columns: ['to_user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "partner_requests_to_user_id_fkey"
+            columns: ["to_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       photos: {
         Row: {
-          caption: string | null;
-          created_at: string;
-          file_size: number;
-          filename: string;
-          height: number;
-          id: string;
-          mime_type: string;
-          storage_path: string;
-          user_id: string;
-          width: number;
-        };
+          caption: string | null
+          created_at: string
+          file_size: number
+          filename: string
+          height: number
+          id: string
+          mime_type: string
+          storage_path: string
+          user_id: string
+          width: number
+        }
         Insert: {
-          caption?: string | null;
-          created_at?: string;
-          file_size: number;
-          filename: string;
-          height: number;
-          id?: string;
-          mime_type?: string;
-          storage_path: string;
-          user_id: string;
-          width: number;
-        };
+          caption?: string | null
+          created_at?: string
+          file_size: number
+          filename: string
+          height: number
+          id?: string
+          mime_type?: string
+          storage_path: string
+          user_id: string
+          width: number
+        }
         Update: {
-          caption?: string | null;
-          created_at?: string;
-          file_size?: number;
-          filename?: string;
-          height?: number;
-          id?: string;
-          mime_type?: string;
-          storage_path?: string;
-          user_id?: string;
-          width?: number;
-        };
-        Relationships: [];
-      };
+          caption?: string | null
+          created_at?: string
+          file_size?: number
+          filename?: string
+          height?: number
+          id?: string
+          mime_type?: string
+          storage_path?: string
+          user_id?: string
+          width?: number
+        }
+        Relationships: []
+      }
       scripture_bookmarks: {
         Row: {
-          created_at: string;
-          id: string;
-          session_id: string;
-          share_with_partner: boolean;
-          step_index: number;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          session_id: string
+          share_with_partner: boolean
+          step_index: number
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          session_id: string;
-          share_with_partner?: boolean;
-          step_index: number;
-          user_id: string;
-        };
+          created_at?: string
+          id?: string
+          session_id: string
+          share_with_partner?: boolean
+          step_index: number
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          session_id?: string;
-          share_with_partner?: boolean;
-          step_index?: number;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          session_id?: string
+          share_with_partner?: boolean
+          step_index?: number
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'scripture_bookmarks_session_id_fkey';
-            columns: ['session_id'];
-            isOneToOne: false;
-            referencedRelation: 'scripture_sessions';
-            referencedColumns: ['id'];
+            foreignKeyName: "scripture_bookmarks_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "scripture_sessions"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       scripture_messages: {
         Row: {
-          created_at: string;
-          id: string;
-          message: string;
-          sender_id: string;
-          session_id: string;
-        };
+          created_at: string
+          id: string
+          message: string
+          sender_id: string
+          session_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          message: string;
-          sender_id: string;
-          session_id: string;
-        };
+          created_at?: string
+          id?: string
+          message: string
+          sender_id: string
+          session_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          message?: string;
-          sender_id?: string;
-          session_id?: string;
-        };
+          created_at?: string
+          id?: string
+          message?: string
+          sender_id?: string
+          session_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'scripture_messages_session_id_fkey';
-            columns: ['session_id'];
-            isOneToOne: false;
-            referencedRelation: 'scripture_sessions';
-            referencedColumns: ['id'];
+            foreignKeyName: "scripture_messages_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "scripture_sessions"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       scripture_reflections: {
         Row: {
-          created_at: string;
-          id: string;
-          is_shared: boolean;
-          notes: string | null;
-          rating: number | null;
-          session_id: string;
-          step_index: number;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          is_shared: boolean
+          notes: string | null
+          rating: number | null
+          session_id: string
+          step_index: number
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          is_shared?: boolean;
-          notes?: string | null;
-          rating?: number | null;
-          session_id: string;
-          step_index: number;
-          user_id: string;
-        };
+          created_at?: string
+          id?: string
+          is_shared?: boolean
+          notes?: string | null
+          rating?: number | null
+          session_id: string
+          step_index: number
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          is_shared?: boolean;
-          notes?: string | null;
-          rating?: number | null;
-          session_id?: string;
-          step_index?: number;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          is_shared?: boolean
+          notes?: string | null
+          rating?: number | null
+          session_id?: string
+          step_index?: number
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'scripture_reflections_session_id_fkey';
-            columns: ['session_id'];
-            isOneToOne: false;
-            referencedRelation: 'scripture_sessions';
-            referencedColumns: ['id'];
+            foreignKeyName: "scripture_reflections_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "scripture_sessions"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       scripture_sessions: {
         Row: {
-          completed_at: string | null;
-          countdown_started_at: string | null;
-          current_phase: Database['public']['Enums']['scripture_session_phase'];
-          current_step_index: number;
-          id: string;
-          mode: Database['public']['Enums']['scripture_session_mode'];
-          snapshot_json: Json | null;
-          started_at: string;
-          status: Database['public']['Enums']['scripture_session_status'];
-          user1_id: string;
-          user1_ready: boolean;
-          user1_role: Database['public']['Enums']['scripture_session_role'] | null;
-          user2_id: string | null;
-          user2_ready: boolean;
-          user2_role: Database['public']['Enums']['scripture_session_role'] | null;
-          version: number;
-        };
+          completed_at: string | null
+          countdown_started_at: string | null
+          current_phase: Database["public"]["Enums"]["scripture_session_phase"]
+          current_step_index: number
+          id: string
+          mode: Database["public"]["Enums"]["scripture_session_mode"]
+          snapshot_json: Json | null
+          started_at: string
+          status: Database["public"]["Enums"]["scripture_session_status"]
+          user1_id: string
+          user1_ready: boolean
+          user1_role:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          user2_id: string | null
+          user2_ready: boolean
+          user2_role:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          version: number
+        }
         Insert: {
-          completed_at?: string | null;
-          countdown_started_at?: string | null;
-          current_phase?: Database['public']['Enums']['scripture_session_phase'];
-          current_step_index?: number;
-          id?: string;
-          mode: Database['public']['Enums']['scripture_session_mode'];
-          snapshot_json?: Json | null;
-          started_at?: string;
-          status?: Database['public']['Enums']['scripture_session_status'];
-          user1_id: string;
-          user1_ready?: boolean;
-          user1_role?: Database['public']['Enums']['scripture_session_role'] | null;
-          user2_id?: string | null;
-          user2_ready?: boolean;
-          user2_role?: Database['public']['Enums']['scripture_session_role'] | null;
-          version?: number;
-        };
+          completed_at?: string | null
+          countdown_started_at?: string | null
+          current_phase?: Database["public"]["Enums"]["scripture_session_phase"]
+          current_step_index?: number
+          id?: string
+          mode: Database["public"]["Enums"]["scripture_session_mode"]
+          snapshot_json?: Json | null
+          started_at?: string
+          status?: Database["public"]["Enums"]["scripture_session_status"]
+          user1_id: string
+          user1_ready?: boolean
+          user1_role?:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          user2_id?: string | null
+          user2_ready?: boolean
+          user2_role?:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          version?: number
+        }
         Update: {
-          completed_at?: string | null;
-          countdown_started_at?: string | null;
-          current_phase?: Database['public']['Enums']['scripture_session_phase'];
-          current_step_index?: number;
-          id?: string;
-          mode?: Database['public']['Enums']['scripture_session_mode'];
-          snapshot_json?: Json | null;
-          started_at?: string;
-          status?: Database['public']['Enums']['scripture_session_status'];
-          user1_id?: string;
-          user1_ready?: boolean;
-          user1_role?: Database['public']['Enums']['scripture_session_role'] | null;
-          user2_id?: string | null;
-          user2_ready?: boolean;
-          user2_role?: Database['public']['Enums']['scripture_session_role'] | null;
-          version?: number;
-        };
-        Relationships: [];
-      };
+          completed_at?: string | null
+          countdown_started_at?: string | null
+          current_phase?: Database["public"]["Enums"]["scripture_session_phase"]
+          current_step_index?: number
+          id?: string
+          mode?: Database["public"]["Enums"]["scripture_session_mode"]
+          snapshot_json?: Json | null
+          started_at?: string
+          status?: Database["public"]["Enums"]["scripture_session_status"]
+          user1_id?: string
+          user1_ready?: boolean
+          user1_role?:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          user2_id?: string | null
+          user2_ready?: boolean
+          user2_role?:
+            | Database["public"]["Enums"]["scripture_session_role"]
+            | null
+          version?: number
+        }
+        Relationships: []
+      }
       scripture_step_states: {
         Row: {
-          advanced_at: string | null;
-          id: string;
-          session_id: string;
-          step_index: number;
-          user1_locked_at: string | null;
-          user2_locked_at: string | null;
-        };
+          advanced_at: string | null
+          id: string
+          session_id: string
+          step_index: number
+          user1_locked_at: string | null
+          user2_locked_at: string | null
+        }
         Insert: {
-          advanced_at?: string | null;
-          id?: string;
-          session_id: string;
-          step_index: number;
-          user1_locked_at?: string | null;
-          user2_locked_at?: string | null;
-        };
+          advanced_at?: string | null
+          id?: string
+          session_id: string
+          step_index: number
+          user1_locked_at?: string | null
+          user2_locked_at?: string | null
+        }
         Update: {
-          advanced_at?: string | null;
-          id?: string;
-          session_id?: string;
-          step_index?: number;
-          user1_locked_at?: string | null;
-          user2_locked_at?: string | null;
-        };
+          advanced_at?: string | null
+          id?: string
+          session_id?: string
+          step_index?: number
+          user1_locked_at?: string | null
+          user2_locked_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'scripture_step_states_session_id_fkey';
-            columns: ['session_id'];
-            isOneToOne: false;
-            referencedRelation: 'scripture_sessions';
-            referencedColumns: ['id'];
+            foreignKeyName: "scripture_step_states_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "scripture_sessions"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       users: {
         Row: {
-          created_at: string | null;
-          device_id: string | null;
-          display_name: string | null;
-          email: string | null;
-          id: string;
-          partner_id: string | null;
-          partner_name: string | null;
-          updated_at: string | null;
-        };
+          created_at: string | null
+          device_id: string | null
+          display_name: string | null
+          email: string | null
+          id: string
+          partner_id: string | null
+          partner_name: string | null
+          updated_at: string | null
+        }
         Insert: {
-          created_at?: string | null;
-          device_id?: string | null;
-          display_name?: string | null;
-          email?: string | null;
-          id: string;
-          partner_id?: string | null;
-          partner_name?: string | null;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          device_id?: string | null
+          display_name?: string | null
+          email?: string | null
+          id: string
+          partner_id?: string | null
+          partner_name?: string | null
+          updated_at?: string | null
+        }
         Update: {
-          created_at?: string | null;
-          device_id?: string | null;
-          display_name?: string | null;
-          email?: string | null;
-          id?: string;
-          partner_id?: string | null;
-          partner_name?: string | null;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          device_id?: string | null
+          display_name?: string | null
+          email?: string | null
+          id?: string
+          partner_id?: string | null
+          partner_name?: string | null
+          updated_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'users_partner_id_fkey';
-            columns: ['partner_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "users_partner_id_fkey"
+            columns: ["partner_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       accept_partner_request: {
-        Args: { p_request_id: string };
-        Returns: undefined;
-      };
+        Args: { p_request_id: string }
+        Returns: undefined
+      }
       decline_partner_request: {
-        Args: { p_request_id: string };
-        Returns: undefined;
-      };
-      get_my_partner_id: { Args: never; Returns: string };
+        Args: { p_request_id: string }
+        Returns: undefined
+      }
+      get_my_partner_id: { Args: never; Returns: string }
       is_scripture_session_member: {
-        Args: { p_session_id: string };
-        Returns: boolean;
-      };
+        Args: { p_session_id: string }
+        Returns: boolean
+      }
       scripture_convert_to_solo: {
-        Args: { p_session_id: string };
-        Returns: Json;
-      };
+        Args: { p_session_id: string }
+        Returns: Json
+      }
       scripture_create_session: {
-        Args: { p_mode: string; p_partner_id?: string };
-        Returns: Json;
-      };
-      scripture_end_session: { Args: { p_session_id: string }; Returns: Json };
-      scripture_get_couple_stats: { Args: never; Returns: Json };
+        Args: { p_mode: string; p_partner_id?: string }
+        Returns: Json
+      }
+      scripture_end_session: { Args: { p_session_id: string }; Returns: Json }
+      scripture_get_couple_stats: { Args: never; Returns: Json }
       scripture_lock_in: {
         Args: {
-          p_expected_version: number;
-          p_session_id: string;
-          p_step_index: number;
-        };
-        Returns: Json;
-      };
+          p_expected_version: number
+          p_session_id: string
+          p_step_index: number
+        }
+        Returns: Json
+      }
       scripture_seed_test_data: {
         Args: {
-          p_bookmark_steps?: number[];
-          p_include_messages?: boolean;
-          p_include_reflections?: boolean;
-          p_preset?: string;
-          p_session_count?: number;
-        };
-        Returns: Json;
-      };
+          p_bookmark_steps?: number[]
+          p_include_messages?: boolean
+          p_include_reflections?: boolean
+          p_preset?: string
+          p_session_count?: number
+        }
+        Returns: Json
+      }
       scripture_select_role: {
-        Args: { p_role: string; p_session_id: string };
-        Returns: Json;
-      };
+        Args: { p_role: string; p_session_id: string }
+        Returns: Json
+      }
       scripture_submit_reflection: {
         Args: {
-          p_is_shared: boolean;
-          p_notes: string;
-          p_rating: number;
-          p_session_id: string;
-          p_step_index: number;
-        };
-        Returns: Json;
-      };
+          p_is_shared: boolean
+          p_notes: string
+          p_rating: number
+          p_session_id: string
+          p_step_index: number
+        }
+        Returns: Json
+      }
       scripture_toggle_ready: {
-        Args: { p_is_ready: boolean; p_session_id: string };
-        Returns: Json;
-      };
+        Args: { p_is_ready: boolean; p_session_id: string }
+        Returns: Json
+      }
       scripture_undo_lock_in: {
-        Args: { p_session_id: string; p_step_index: number };
-        Returns: Json;
-      };
-    };
+        Args: { p_session_id: string; p_step_index: number }
+        Returns: Json
+      }
+    }
     Enums: {
-      scripture_session_mode: 'solo' | 'together';
+      scripture_session_mode: "solo" | "together"
       scripture_session_phase:
-        | 'lobby'
-        | 'countdown'
-        | 'reading'
-        | 'reflection'
-        | 'report'
-        | 'complete';
-      scripture_session_role: 'reader' | 'responder';
+        | "lobby"
+        | "countdown"
+        | "reading"
+        | "reflection"
+        | "report"
+        | "complete"
+      scripture_session_role: "reader" | "responder"
       scripture_session_status:
-        | 'pending'
-        | 'in_progress'
-        | 'complete'
-        | 'abandoned'
-        | 'ended_early';
-    };
+        | "pending"
+        | "in_progress"
+        | "complete"
+        | "abandoned"
+        | "ended_early"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   graphql_public: {
@@ -670,17 +708,24 @@ export const Constants = {
   },
   public: {
     Enums: {
-      scripture_session_mode: ['solo', 'together'],
+      scripture_session_mode: ["solo", "together"],
       scripture_session_phase: [
-        'lobby',
-        'countdown',
-        'reading',
-        'reflection',
-        'report',
-        'complete',
+        "lobby",
+        "countdown",
+        "reading",
+        "reflection",
+        "report",
+        "complete",
       ],
-      scripture_session_role: ['reader', 'responder'],
-      scripture_session_status: ['pending', 'in_progress', 'complete', 'abandoned', 'ended_early'],
+      scripture_session_role: ["reader", "responder"],
+      scripture_session_status: [
+        "pending",
+        "in_progress",
+        "complete",
+        "abandoned",
+        "ended_early",
+      ],
     },
   },
-} as const;
+} as const
+


### PR DESCRIPTION
Three of the four `bmad-document-project` findings. Each verified against the code and the **live schema** before changing anything.

Finding 4 (the Fart button) is deliberately **not** fixed here — see below.

---

## 1. `photosSlice.updatePhoto` reported success it didn't achieve

`photoService.updatePhoto` returns `boolean` and persists **caption only**. The slice ignored that return value — despite a comment reading *"Update in state on successful update"* — and merged the entire `Partial<SupabasePhoto>` into local state.

Two user-visible consequences:

1. A **rejected write still updated the UI**. The change vanished on reload.
2. Fields with no backing column were displayed as saved.

The second is not hypothetical. `PhotoEditModal` sends `tags`, with a full input, a 10-tag cap, and per-tag length validation. But `photos` has **no tags column**:

```
id, user_id, storage_path, filename, caption, mime_type, file_size, width, height, created_at
```

So tag editing looked like it worked until reload, every time.

Now: checks the boolean, surfaces an error on failure, merges only `caption`.

> ⚠️ **This makes tag editing visibly stop working**, which is the honest state. That UI is entirely unbacked and needs a product decision — add a `tags` column, or remove the input. This PR only stops the lie; it doesn't pick.

## 2. `database.types.ts` regenerated

Was missing `claude_bot_config` from migration `20260316031209`.

Verified the regeneration is semantically additive — `claude_bot_config` is the **only** identifier gained, and **none were lost** (diffed the full identifier sets both ways). The large line count is formatting: the committed copy was Prettier-formatted, and Prettier was removed in #221, so the generator's own output is now canonical.

## 3. `dbSchema.ts` comments now describe what the code does

- Dropped `photoStorageService.ts` from the "Used by" list — that file no longer exists.
- Replaced the v1→v2 note claiming data preservation *"is handled in photoStorageService"*. It is not handled anywhere: the upgrade drops and recreates the store.

Documented as **deliberately** destructive, with the reason: photos are Supabase-first, so IndexedDB is a read cache that refills on the next fetch. Restoring preservation would mean reintroducing an async migration step for a cache that costs nothing to rebuild.

---

## Not fixed: the Fart button (finding 4)

Confirmed exactly as reported — `handleFart` sets local animation/cooldown state and nothing else. No store action (`interactionsSlice` has only `sendPoke`/`sendKiss`), no network call, and the DB type is `CREATE TYPE interaction_type AS ENUM ('poke', 'kiss')` with a matching CHECK constraint.

Making it real means a migration to extend the enum plus service and slice work — that's a feature, not a bug fix, and it's your call. It's the same class of problem as photo tags: **UI for something the backend doesn't have.**

---

Typecheck clean, lint 0 errors, **896 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w2GfXiUVcD43zZ5Re4Wtg