### PR TITLE
fix(lint): take react-hooks warnings from 13 to 0

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,7 +111,11 @@ function App() {
 
   const [showSplash, setShowSplash] = useState(shouldShowWelcome);
   const [splashSource, setSplashSource] = useState<'auto' | 'manual'>('auto');
-  const [showAdmin, setShowAdmin] = useState(false);
+  // Decided once, by the URL the page was loaded with, so it belongs in the initializer
+  // rather than in a mount effect that needs a second render to correct itself. Nothing
+  // re-derives this from the URL later: after mount the flag belongs entirely to
+  // handleAdminExit, whose pushState is URL bookkeeping and never reads back into state.
+  const [showAdmin, setShowAdmin] = useState(() => window.location.pathname.includes('/admin'));
   const [isPhotoUploadOpen, setIsPhotoUploadOpen] = useState(false);
 
   // Story 1.5: Sync completion feedback state (AC-1.5.4)
@@ -145,12 +149,6 @@ function App() {
 
   // Story 4.5: Initial route detection and popstate listener (AC-4.5.5, AC-4.5.6)
   useEffect(() => {
-    // Check admin route (does not short-circuit: routing must still be wired up
-    // so Back/Forward keeps working after the user exits the admin panel)
-    if (window.location.pathname.includes('/admin')) {
-      setShowAdmin(true);
-    }
-
     // AC-4.5.5: Initial route detection - set view based on URL
     const routePath = getRoutePath(window.location.pathname);
     const initialView =

--- a/src/components/MoodHistory/MoodHistoryCalendar.tsx
+++ b/src/components/MoodHistory/MoodHistoryCalendar.tsx
@@ -106,6 +106,14 @@ export function MoodHistoryCalendar() {
 
   // Load moods when month changes
   useEffect(() => {
+    // loadMoodsForMonth flips isLoading before it awaits Supabase, and clears the mood state
+    // outright when nobody is signed in. Both are the synchronous setState the rule objects
+    // to, but they are the begin-fetch and no-session transitions of an external data
+    // lifecycle rather than anything derivable at render time. Removing them means collapsing
+    // moods/moodMap/isLoading into one month-keyed state and deriving loading during render,
+    // which changes the first frame signed-out users see and the render count on every month
+    // change — and this component has no test coverage that would catch the regression.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch lifecycle, see above
     loadMoodsForMonth(currentYear, currentMonth);
   }, [currentYear, currentMonth, loadMoodsForMonth]);
 

--- a/src/components/MoodHistory/MoodHistoryCalendar.tsx
+++ b/src/components/MoodHistory/MoodHistoryCalendar.tsx
@@ -106,14 +106,21 @@ export function MoodHistoryCalendar() {
 
   // Load moods when month changes
   useEffect(() => {
-    // loadMoodsForMonth flips isLoading before it awaits Supabase, and clears the mood state
+    // loadMoodsForMonth flips isLoading before its first await, and clears the mood state
     // outright when nobody is signed in. Both are the synchronous setState the rule objects
-    // to, but they are the begin-fetch and no-session transitions of an external data
-    // lifecycle rather than anything derivable at render time. Removing them means collapsing
-    // moods/moodMap/isLoading into one month-keyed state and deriving loading during render,
-    // which changes the first frame signed-out users see and the render count on every month
-    // change — and this component has no test coverage that would catch the regression.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch lifecycle, see above
+    // to, but they are the begin-read and no-session transitions of a store lifecycle that
+    // lives outside React, not values derivable at render time.
+    //
+    // To be accurate about what is being awaited: getMoodsInRange is a local IndexedDB
+    // range scan, not a network call — so the skeleton this flag drives is usually on
+    // screen for a frame at most. The exception is the first read of a session, where
+    // BaseIndexedDBService.init() may be opening the database and running a schema upgrade.
+    //
+    // Removing the flag means collapsing moods/moodMap/isLoading into one month-keyed state
+    // and deriving loading during render. That changes the first frame signed-out users see
+    // and the render count on every month change, and this component has no test coverage
+    // that would catch a regression, so it is not a change to make in a lint sweep.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- store read lifecycle, see above
     loadMoodsForMonth(currentYear, currentMonth);
   }, [currentYear, currentMonth, loadMoodsForMonth]);
 

--- a/src/components/MoodTracker/MoodTracker.tsx
+++ b/src/components/MoodTracker/MoodTracker.tsx
@@ -23,7 +23,7 @@ import { useEffect, useState } from 'react';
 import { getPartnerId } from '../../api/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import { useAppStore } from '../../stores/useAppStore';
-import type { MoodType } from '../../types';
+import type { MoodEntry, MoodType } from '../../types';
 import { registerBackgroundSync } from '../../utils/backgroundSync';
 import { formatDateISO } from '../../utils/dateUtils';
 import { triggerErrorHaptic, triggerMoodSaveHaptic } from '../../utils/haptics';
@@ -141,8 +141,21 @@ export function MoodTracker() {
     };
   }, []);
 
-  // Check if mood already exists for today (AC-5)
-  useEffect(() => {
+  // Seed the form from today's saved entry (AC-5). This used to be an effect keyed on
+  // `moods`, which cost a second commit every time it fired — the store outlives this view,
+  // so returning to the Mood tab could paint an empty form for a frame before the saved
+  // entry landed in it. Adjusting state during render collapses that into one commit.
+  //
+  // The trigger is deliberately unchanged: first render, then any render where `moods` is a
+  // different array than the one already seeded from. That fires more often than the
+  // contents actually change, since loadMoods hands back a fresh array after every sync,
+  // and reseeding overwrites whatever is in the form — exactly what the effect did. The
+  // `null` sentinel is what makes the first render count; seeding it from `moods` would skip
+  // a remount where the store is already populated.
+  const [seededFrom, setSeededFrom] = useState<MoodEntry[] | null>(null);
+  if (moods !== seededFrom) {
+    setSeededFrom(moods);
+
     const today = formatDateISO(new Date());
     const existingMood = getMoodForDate(today);
 
@@ -160,7 +173,7 @@ export function MoodTracker() {
         setShowNoteField(true);
       }
     }
-  }, [getMoodForDate, moods]);
+  }
 
   const handleMoodSelect = (mood: MoodType) => {
     setSelectedMoods((prev) => {

--- a/src/components/MoodTracker/MoodTracker.tsx
+++ b/src/components/MoodTracker/MoodTracker.tsx
@@ -152,6 +152,12 @@ export function MoodTracker() {
   // and reseeding overwrites whatever is in the form — exactly what the effect did. The
   // `null` sentinel is what makes the first render count; seeding it from `moods` would skip
   // a remount where the store is already populated.
+  //
+  // The `new Date()` below is an impure read that has moved into the render path. It runs
+  // only inside this branch, and only to pick which saved entry to seed from, so the worst
+  // it can do is straddle a midnight rollover — the same exposure the effect had. Note that
+  // react-hooks/purity does not flag `new Date()` (it flags `Date.now()`), so the linter
+  // will not catch it if this block is ever widened to run on every render.
   const [seededFrom, setSeededFrom] = useState<MoodEntry[] | null>(null);
   if (moods !== seededFrom) {
     setSeededFrom(moods);

--- a/src/components/PartnerMoodView/PartnerMoodView.tsx
+++ b/src/components/PartnerMoodView/PartnerMoodView.tsx
@@ -140,14 +140,24 @@ export function PartnerMoodView() {
   // still showed the moods fetched before going offline.
   useEffect(() => {
     if (syncStatus.isOnline && partner) {
+      // handleRefresh raises isRefreshing before it awaits, and that ordering is the point:
+      // the spinner and the "Loading partner moods..." panel are the only signal that a
+      // fetch is in flight, so deferring the flag past the await would leave the view
+      // looking idle for the whole Supabase round trip. There is nothing to derive it from
+      // either — the fetch lifecycle lives outside React.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch lifecycle
       handleRefresh();
     }
   }, [syncStatus.isOnline, partner, handleRefresh]);
 
   // Story 6.4: Task 6 & 7 - Real-time subscription with connection status (AC #4)
   useEffect(() => {
+    // The offline branch deliberately does not reset connectionStatus. This effect's own
+    // cleanup already sets 'disconnected', and React runs it before the body re-runs on the
+    // online -> offline flip; a first render that is already offline starts at 'disconnected'
+    // from useState. The reset that used to sit here only ever rewrote the value it was about
+    // to read, and charged a cascading render for it.
     if (!syncStatus.isOnline) {
-      setConnectionStatus('disconnected');
       return; // Don't subscribe when offline
     }
 

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -1,7 +1,7 @@
 import type { PanInfo } from 'framer-motion';
 import { AnimatePresence, motion, useMotionValue } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Loader2, Trash2, X } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFocusTrap } from '../../hooks';
 import type { PhotoWithUrls } from '../../services/photoService';
 import { useAppStore } from '../../stores/useAppStore';
@@ -59,9 +59,6 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   const x = useMotionValue(0);
   const y = useMotionValue(0);
 
-  // Ref for image to calculate pan boundaries
-  const imageRef = useRef<HTMLImageElement>(null);
-
   // AC 6.4.12 & WCAG 2.4.3: Focus trap for modal
   const containerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(containerRef, true, { onEscape: onClose });
@@ -70,18 +67,30 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   const canNavigatePrev = currentIndex > 0;
   const canNavigateNext = currentIndex < photos.length - 1;
 
+  // The image's intrinsic size is not a layout measurement — the browser hands it to us on
+  // the load event, so we record it there instead of reading it back off an element ref
+  // afterwards. Reading the ref during render was the original bug: on the first render the
+  // <img> is not mounted, so the pan boundaries came back as the zero box and the photo
+  // could not be panned until some unrelated re-render recomputed them. With the size in
+  // state the boundaries become a pure function of (intrinsic size, zoom) and can be derived
+  // during render — no measure-then-setState round trip, and no render where a zoomed photo
+  // is stuck with the previous photo's box.
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+
   // AC 6.4.6: Calculate dynamic pan boundaries based on zoom level
-  const calculateDragConstraints = useCallback(() => {
-    if (!imageRef.current || scale <= MIN_ZOOM) {
+  const dragConstraints = useMemo(() => {
+    // A zero size means the image has not reported its dimensions yet — never loaded, or the
+    // load failed — so there is nothing to pan inside. Same no-pan box the old unmounted-ref
+    // guard returned.
+    if (naturalSize.width === 0 || naturalSize.height === 0 || scale <= MIN_ZOOM) {
       return { left: 0, right: 0, top: 0, bottom: 0 };
     }
 
-    const img = imageRef.current;
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight - 200; // Account for controls and overlays
 
     // Calculate rendered image size using object-contain logic
-    const imgAspect = img.naturalWidth / img.naturalHeight;
+    const imgAspect = naturalSize.width / naturalSize.height;
     const viewportAspect = viewportWidth / viewportHeight;
 
     let renderedWidth: number;
@@ -111,24 +120,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       top: -maxY,
       bottom: maxY,
     };
-  }, [scale]);
-
-  // Measured, not computed during render. Calling calculateDragConstraints()
-  // inline in JSX read imageRef.current while rendering, and on the first render
-  // the <img> is not mounted yet — so it returned the zero box and the image
-  // could not be panned until an unrelated re-render happened to recompute it.
-  // isLoading flips in the image's onLoad handler, which is exactly when
-  // naturalWidth/naturalHeight become readable.
-  const [dragConstraints, setDragConstraints] = useState({
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-  });
-
-  useEffect(() => {
-    setDragConstraints(calculateDragConstraints());
-  }, [calculateDragConstraints, currentIndex, isLoading]);
+  }, [naturalSize, scale]);
 
   // AC 6.4.11: Photo preloading
   useEffect(() => {
@@ -332,12 +324,20 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   }, [photos, currentIndex, canNavigateNext, onClose, deletePhoto, resetTransform]);
 
   // AC 6.4.15: Image loading handlers
-  const handleImageLoad = useCallback(() => {
+  const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    setNaturalSize({ width: img.naturalWidth, height: img.naturalHeight });
     setIsLoading(false);
     setImageError(false);
   }, []);
 
   const handleImageError = useCallback(() => {
+    // Clearing the size is what keeps the failure state un-pannable. The <img> unmounts on
+    // error, but the outer motion.div keeps its drag and double-tap handlers, so a stale
+    // size from the previous photo would hand a zoomed error card a real drag box — and
+    // handleDragEnd returns early while zoomed, before it recentres, so the offset would
+    // survive a retry with nothing to spring it back.
+    setNaturalSize({ width: 0, height: 0 });
     setIsLoading(false);
     setImageError(true);
   }, []);
@@ -452,7 +452,6 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
             {/* AC 6.4.1: Photo display */}
             {!imageError && (
               <motion.img
-                ref={imageRef}
                 key={currentPhoto.id} // Force remount on photo change
                 src={currentPhoto.signedUrl || ''}
                 alt={currentPhoto.caption || 'Photo'}

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -162,6 +162,13 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     y.set(0);
     setImageError(false);
     setIsLoading(true);
+    // The incoming photo has not reported its size yet, and the outgoing one's is no longer
+    // true of anything on screen. Zeroing here holds the same invariant handleImageError
+    // does — no image reporting a size means no pan — and closes the window where a
+    // double-tap during the new photo's load would size its drag box from the old aspect
+    // ratio. The ref-reading effect this replaced got the clearing for free, because
+    // key={photo.id} remounts the <img> and naturalWidth is 0 until decode.
+    setNaturalSize({ width: 0, height: 0 });
   }, [x, y]);
 
   // Navigate to next/previous photo

--- a/src/components/PokeKissInterface/PokeKissInterface.tsx
+++ b/src/components/PokeKissInterface/PokeKissInterface.tsx
@@ -48,6 +48,18 @@ const getCooldownRemaining = (type: 'poke' | 'kiss' | 'fart'): number => {
   return Math.max(0, RATE_LIMIT_MS - elapsed);
 };
 
+// Stamp the moment an interaction was sent, for getCooldownRemaining to measure against.
+//
+// Module scope here is load-bearing rather than tidiness. react-hooks/purity treats a
+// Date.now() call reached from a component body as an impure read during render, and it
+// flagged exactly the two senders that reach theirs after an `await` -- handleFart, whose
+// identical write is never awaited past, went unreported. Reading the clock beside the
+// helper that interprets it puts all three senders on the same footing and keeps the rule
+// from re-firing the next time one of them grows an await.
+const recordInteractionTime = (type: 'poke' | 'kiss' | 'fart'): void => {
+  localStorage.setItem(RATE_LIMIT_KEYS[type], Date.now().toString());
+};
+
 // Format cooldown as minutes:seconds
 const formatCooldown = (ms: number): string => {
   const minutes = Math.floor(ms / 60000);
@@ -164,7 +176,7 @@ export function PokeKissInterface({ expandDirection = 'up' }: PokeKissInterfaceP
 
     try {
       await sendPoke(partnerId);
-      localStorage.setItem(RATE_LIMIT_KEYS.poke, Date.now().toString());
+      recordInteractionTime('poke');
       setPokeCooldown(RATE_LIMIT_MS);
       setShowToast('Poke sent! 👆');
       setTimeout(() => setShowToast(null), 2000);
@@ -198,7 +210,7 @@ export function PokeKissInterface({ expandDirection = 'up' }: PokeKissInterfaceP
 
     try {
       await sendKiss(partnerId);
-      localStorage.setItem(RATE_LIMIT_KEYS.kiss, Date.now().toString());
+      recordInteractionTime('kiss');
       setKissCooldown(RATE_LIMIT_MS);
       setShowToast('Kiss sent! 💋');
       setTimeout(() => setShowToast(null), 2000);
@@ -223,7 +235,7 @@ export function PokeKissInterface({ expandDirection = 'up' }: PokeKissInterfaceP
     setIsExpanded(false);
 
     try {
-      localStorage.setItem(RATE_LIMIT_KEYS.fart, Date.now().toString());
+      recordInteractionTime('fart');
       setFartCooldown(RATE_LIMIT_MS);
       setShowAnimation('fart');
       setShowToast('💨 Fart sent!');

--- a/src/components/scripture-reading/containers/ReadingContainer.tsx
+++ b/src/components/scripture-reading/containers/ReadingContainer.tsx
@@ -110,7 +110,6 @@ export function ReadingContainer(): ReactElement | null {
         void loadSession(session.id);
       }
       // Story 4.3: Show "Reconnected" toast (green tint, 2s auto-dismiss)
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- presence transition drives toast
       setShowReconnectedToast(true);
       if (reconnectedToastTimerRef.current) clearTimeout(reconnectedToastTimerRef.current);
       reconnectedToastTimerRef.current = setTimeout(() => setShowReconnectedToast(false), 2000);
@@ -172,7 +171,6 @@ export function ReadingContainer(): ReactElement | null {
   useEffect(() => {
     if (session && session.currentStepIndex !== prevStepRef.current) {
       prevStepRef.current = session.currentStepIndex;
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- view reset on step navigation
       setLocalView('verse');
     }
   }, [session?.currentStepIndex, session]);

--- a/src/components/scripture-reading/hooks/useReportPhase.ts
+++ b/src/components/scripture-reading/hooks/useReportPhase.ts
@@ -288,6 +288,12 @@ export function useReportPhase({
     let isActive = true;
 
     if (!hasPartner) {
+      // The unlinked screen has to be on screen while the completion RPC below is still in
+      // flight; deferring this into that async block would leave 'compose' rendered for a
+      // full round trip. reportSubPhase is control state, not a derivation — handleMessageSend,
+      // handleMessageSkip and handleRetrySessionCompletion write it too, including
+      // 'completion-error', which no combination of session and partner props can express.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- unlinked screen must render before the completion RPC resolves
       setReportSubPhase('complete-unlinked');
       if (session.currentPhase === 'complete' || session.status === 'complete') {
         setCompletionError(null);
@@ -323,6 +329,11 @@ export function useReportPhase({
   // Story 2.3: Load report data when report view is actually displayed
   useEffect(() => {
     if ((reportSubPhase !== 'report' && reportSubPhase !== 'complete-unlinked') || !session) return;
+    // Clearing the previous failure here, rather than only in handleRetryReportLoad, is what
+    // stops a stale error banner outliving its request when a changed session object
+    // re-triggers this load on its own. Hiding it inside the async block below would run at
+    // the same moment and only move it out of the linter's view.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clears the stale failure banner for the load starting below
     setReportLoadError(null);
 
     let isActive = true;

--- a/src/hooks/useMoodHistory.ts
+++ b/src/hooks/useMoodHistory.ts
@@ -69,6 +69,13 @@ export function useMoodHistory(userId: string): UseMoodHistoryReturn {
   }, [userId]);
 
   useEffect(() => {
+    // The synchronous setIsLoading(true)/setError(null) inside loadInitialMoods is the point,
+    // not an oversight: the timeline has to paint its skeleton on the render right after mount
+    // instead of sitting on a stale empty state for a network round trip. loadInitialMoods is
+    // also the exposed `retry`, so the kickoff cannot move out of it, and a paginated fetch
+    // accumulating pages in local state has nothing to derive during render and no external
+    // store to subscribe to.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch-on-mount lifecycle
     loadInitialMoods();
   }, [loadInitialMoods]);
 


### PR DESCRIPTION
Clears the 13 warnings the eslint 10 / react-hooks 7.1.1 upgrade in #246 surfaced. `main` had 0 before that upgrade, so this restores a clean baseline.

Three were real bugs, one of which the warning was actively hiding.

## Real fixes

**`App.tsx`** — `showAdmin` was patched in from a mount effect, one render late. The URL a page loaded with is fixed for the lifetime of the mount, so it moves into a lazy `useState` initializer, matching `showSplash` two lines above. Nothing re-derives the flag afterwards (`setShowAdmin` has exactly two call sites).

**`MoodTracker.tsx`** — seeding the form from today's saved entry cost a second commit on every `moods` change, and the store outlives the view, so returning to the Mood tab could paint an empty form for a frame. Now adjusted during render behind a `seededFrom` sentinel. The trigger is deliberately unchanged, *including* a pre-existing wart: reseeding still overwrites the note field whenever `loadMoods` hands back a fresh array (the 5-minute `syncPendingMoods` does this). Preserving that is intentional — changing it is a separate decision, not a lint sweep.

**`PhotoViewer.tsx`** — the intrinsic image size is not a layout measurement; the browser reports it on the load event. It goes into state there rather than being read off a ref, making the pan box a pure function of (size, zoom) derived during render. **This also fixes a bug the warning was masking:** the old effect's deps were `scale`/`currentIndex`/`isLoading`, none of which change when a realtime insert prepends a photo while zoomed — so the drag box could stay stale indefinitely.

`handleImageError` now zeroes the size, and that line is load-bearing. On a failed load the `<img>` unmounts but the wrapping `motion.div` keeps its drag and double-tap handlers, so a leftover size would hand a zoomed error card a real drag box — and `handleDragEnd` returns early while zoomed, *before* it recentres, so the offset would survive a retry with nothing to spring it back. These are expiring signed URLs; the failure path is why the retry card exists. The first version of this patch omitted that line and was rejected in review for exactly this.

**`PartnerMoodView.tsx`** also lost a redundant write — the offline branch reset `connectionStatus` to a value the effect's own cleanup had just set, and that `useState` already initialises to.

## Justified suppressions

The remaining six are begin-read transitions of a data lifecycle outside React. The synchronous setState before the await *is* the behaviour — it paints the skeleton instead of leaving a stale view. Each carries a targeted disable naming its specific reason. None is a file-level or config-level disable.

Also removed two `eslint-disable` directives in `ReadingContainer.tsx` that no longer suppressed anything — they were themselves 2 of the 13, surfaced because eslint 10 defaults `reportUnusedDisableDirectives` to warn.

## Process

Every site was analysed independently and then adversarially re-reviewed. That second pass rejected the PhotoViewer patch, produced the `handleImageError` fix, and caught two comments that overstated their justification — one claimed `loadMoodsForMonth` "awaits Supabase" when it is a local IndexedDB scan. Both corrected in the last commit, since a comment whose only job is to justify a suppression is worthless if it is wrong.

## Verification

`npm run lint` **0 errors, 0 warnings** (from 13) · typecheck · build with all five vendor chunks intact · smoke tests · **1084 unit tests across 73 files**.

The MoodTracker render-phase change was A/B'd against `main`'s component rendered side by side under StrictMode across four sequences (mount, type-then-fresh-array, same-batch, empty-then-repopulate) — byte-identical output, no "Too many re-renders", no cross-component update warning. `moods` comes from a plain `useAppStore((s) => s.moods)` property read, so its identity is stable and the render-phase branch cannot loop.

## Known and disclosed

- `MoodTracker.tsx` now calls `new Date()` during render. Exposure is unchanged from the effect version (a midnight rollover picking the wrong day's entry) and it runs only inside the seeding branch — but `react-hooks/purity` flags `Date.now()` and **not** `new Date()`, so the linter would not catch it if that branch were ever widened. Documented in place.
- Hoisting `recordInteractionTime` to module scope in `PokeKissInterface` means `react-hooks/purity` can no longer see the `Date.now()` through it from any future caller. Kept deliberately: it mirrors the module-scope `getCooldownRemaining` directly above it, which already reads the clock the same way, and it de-duplicates three identical writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XWzgUdKf9EWkVv32H7pt