### PR TITLE
fix(photos): stop Retry from re-zooming the photo it just reset

### DIFF
--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -155,7 +155,8 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     };
   }, [currentIndex, photos, canNavigateNext, canNavigatePrev]);
 
-  // Reset zoom and pan when navigating to different photo
+  // Return the viewer to an untransformed state waiting on a load. Used when navigating to a
+  // different photo and when retrying a failed one — both arrive at the same place.
   const resetTransform = useCallback(() => {
     setScale(MIN_ZOOM);
     x.set(0);
@@ -349,10 +350,25 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     setImageError(true);
   }, []);
 
-  const handleRetryLoad = useCallback(() => {
-    setIsLoading(true);
-    setImageError(false);
-  }, []);
+  // Retry wants exactly what navigation wants: an untransformed viewer waiting on a load. It
+  // shares resetTransform rather than restating it, because these two paths silently drifting
+  // is the whole bug.
+  //
+  // Why the tap is stopped here. onClick={handleDoubleTap} is on the outer motion.div, which
+  // stays mounted while the image is errored — only the <img> is behind the !imageError
+  // guard — and the Retry button is inside it. So one tap on Retry runs both handlers, and
+  // handleDoubleTap's setScale lands second. Tap the error card, then tap Retry a moment
+  // later, and the second tap reads as a double-tap: the reset is immediately undone and the
+  // photo returns at 2x with a live drag box on a card nobody deliberately zoomed. Stopping
+  // propagation also keeps this tap from seeding lastTap for the next tap on the photo that
+  // is about to load.
+  const handleRetryLoad = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      resetTransform();
+    },
+    [resetTransform]
+  );
 
   if (!currentPhoto) {
     return null;

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -170,6 +170,14 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     // ratio. The ref-reading effect this replaced got the clearing for free, because
     // key={photo.id} remounts the <img> and naturalWidth is 0 until decode.
     setNaturalSize({ width: 0, height: 0 });
+    // A tap that landed before the reset must not pair with one that lands after it.
+    // handleDoubleTap only compares `now - lastTap` against DOUBLE_TAP_DELAY, so a stale
+    // timestamp makes the next single tap zoom: tap the error card, tap Retry ~200ms later,
+    // and a single tap on the freshly loaded photo is still inside the 300ms window. Same
+    // shape when navigating — tap photo A, advance, tap photo B quickly. Zero is safe rather
+    // than arbitrary: `now` is epoch milliseconds, so the first comparison after a reset is
+    // never under the threshold.
+    setLastTap(0);
   }, [x, y]);
 
   // Navigate to next/previous photo


### PR DESCRIPTION
Follow-up to the two pre-existing bugs surfaced in review on #247. **Only one of them was real** — see the second half.

## The bug

`handleRetryLoad` cleared `isLoading` and `imageError` but left the transform alone. A user who had tapped the error card came back from a successful retry at 2× with a live drag box, on a photo they never deliberately zoomed.

Two things were wrong, and fixing only the first leaves it reachable:

**1. Retry didn't reset the transform.** It now shares `resetTransform` instead of restating part of it. Both want the identical end state — an untransformed viewer waiting on a load — and these two paths drifting is what produced this in the first place, exactly as `resetTransform` itself was missing the `naturalSize` clearing until 1118de17.

**2. The Retry tap also fires `handleDoubleTap`.** `onClick={handleDoubleTap}` is on the outer `motion.div` (`:432`), which stays mounted while the image is errored — only the `<img>` is behind the `!imageError` guard — and the Retry button is inside it. So one tap runs both handlers, and `handleDoubleTap`'s `setScale` lands **second**. Tap the error card, then tap Retry a moment later — an ordinary impatient gesture — and the second tap reads as a double-tap inside `DOUBLE_TAP_DELAY`, undoing the reset on the spot.

Sharing `resetTransform` alone did not fix that. A reviewer caught it by instrumenting the actual handler order rather than trusting the reasoning:

```
error card tapped once, Retry tapped INSIDE the 300ms window
  resetTransform setScale -> MIN_ZOOM
  handleDoubleTap fired; isDoubleTap= true
  handleDoubleTap setScale -> 2
  render scale = 2          <- the exact state the change claimed to prevent
```

`stopPropagation` also keeps the retry tap from seeding `lastTap` for the next tap on the photo that's about to load.

## The other reported bug does not exist

The review on #247 also reported a MoodTracker cold-start race: `moods` loading from IndexedDB before `onAuthStateChange` populates `userId`, so `getMoodForDate` filters on `null`, seeds nothing, and never retries. I implemented a fix for it (keying the seed sentinel on `(moods, userId)`) with a regression test, and **then had to throw it away.**

`loadMoods` refuses to populate without an owner — `moodSlice.ts:165-169`:

```ts
const userId = get().userId;
if (!userId) {
  set({ moods: [] });
  return;
}
```

So `moods` only becomes non-empty *after* `userId` exists, and that write hands back a new array identity, which the existing sentinel already keys on. Persisted state can't smuggle one in either: `useAppStore.ts:120` deletes `moods` from the rehydrated blob. `App.tsx:430` independently gates the component behind `session`.

The fix was inert, its comment asserted a mechanism the store explicitly prevents, and the regression test pinned a state the store cannot reach. My error was verifying the *mechanism* — `getMoodForDate` does filter on `userId`, which is true — and never checking the *premise* it rested on. Reverted rather than kept as harmless: inert code carrying a false explanation is worse than no code.

## Verification

typecheck · lint 0 errors 0 warnings · build · smoke · 1084 unit tests across 73 files.

No unit coverage for the fix itself — PhotoGallery has no test harness, and standing one up for a framer-motion drag surface is out of proportion to this change. Stated rather than glossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XWzgUdKf9EWkVv32H7pt