### PR TITLE
chore(lint): enforce react-hooks strict rules, and fix the defect the audit found

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,15 @@ export default tseslint.config(
   // Base configs
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  // A disable directive is a written exemption, so a dead one is a false claim about the
+  // code. ESLint reports these as warnings by default and `npm run lint` passes no
+  // --max-warnings, which is how the stale suppressions cleaned up in 2226cc01 and
+  // e9d41bad survived in the first place. Error makes CI reject them.
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.{ts,tsx}'],
     plugins: {
@@ -39,11 +48,14 @@ export default tseslint.config(
       // React Hooks rules
       ...reactHooks.configs.recommended.rules,
 
-      // React 19 strict rules - downgraded to warn for legitimate patterns
-      // These patterns are valid: blob URL lifecycle, timer setup, animation randomization
-      // See: https://react.dev/learn/you-might-not-need-an-effect (these are recommendations, not errors)
-      'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/purity': 'warn',
+      // React 19 strict rules. Every site in the tree is either fixed or carries a
+      // file-local disable directive with a written rationale, so these are errors: a new
+      // violation is a mistake until someone justifies it in place. The legitimate patterns
+      // (blob URL lifecycle, async fetch-on-mount, subscription bridges) stay opted out one
+      // line at a time rather than blanket-downgraded for the whole codebase.
+      // See: https://react.dev/learn/you-might-not-need-an-effect
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/purity': 'error',
 
       // React Refresh rules
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],

--- a/src/components/MoodTracker/__tests__/MoodHistoryTimeline.firstPaint.test.tsx
+++ b/src/components/MoodTracker/__tests__/MoodHistoryTimeline.firstPaint.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * MoodHistoryTimeline — first-commit regression coverage
+ *
+ * The timeline's empty-state guard is `!isLoading && moods.length === 0`, so whatever
+ * useMoodHistory reports as `isLoading` on the first render decides which terminal state
+ * that commit describes. When the flag started `false`, the mount commit rendered
+ * "no mood history yet" — a settled, zero-result answer for a fetch that had not been
+ * issued yet — and swapped to the spinner only on the next commit.
+ *
+ * Whether that reached the user's eye is not asserted here: the panel mounts inside an
+ * AnimatePresence fade, so the offending commit may well paint at opacity 0. The commit
+ * sequence is the contract under test, because it is what was measured.
+ *
+ * Only the network layer is mocked. The real useMoodHistory runs, so this exercises the
+ * genuine mount sequence rather than a hand-built hook state the app cannot reach.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { Profiler } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../api/moodApi', () => ({
+  moodApi: { getMoodHistory: vi.fn() },
+}));
+
+import { moodApi } from '../../../api/moodApi';
+import { MoodHistoryTimeline } from '../MoodHistoryTimeline';
+
+const mockedGetMoodHistory = vi.mocked(moodApi.getMoodHistory);
+
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+
+/** Holds the loading window open so every commit before data arrives is observable. */
+const NEVER_RESOLVES = () => new Promise<never>(() => {});
+
+beforeEach(() => {
+  mockedGetMoodHistory.mockReset();
+});
+
+/**
+ * Profiler.onRender fires after a commit is applied to the DOM, so querying the
+ * document from inside it reports exactly what that commit put on screen.
+ */
+function recordCommits(): { commits: string[]; element: React.ReactElement } {
+  const commits: string[] = [];
+  const element = (
+    <Profiler
+      id="timeline"
+      onRender={() => {
+        const empty = document.querySelector('[data-testid="empty-mood-history-state"]');
+        const list = document.querySelector('[data-testid="mood-history-timeline"]');
+        commits.push(empty ? 'empty-state' : list ? 'timeline' : 'nothing');
+      }}
+    >
+      <MoodHistoryTimeline userId={USER_ID} />
+    </Profiler>
+  );
+  return { commits, element };
+}
+
+describe('MoodHistoryTimeline first paint', () => {
+  it('never paints the empty state while the initial load is still in flight', () => {
+    mockedGetMoodHistory.mockImplementation(NEVER_RESOLVES);
+    const { commits, element } = recordCommits();
+
+    render(element);
+
+    expect(commits).not.toContain('empty-state');
+  });
+
+  it('shows the timeline on the very first commit', () => {
+    mockedGetMoodHistory.mockImplementation(NEVER_RESOLVES);
+    const { commits, element } = recordCommits();
+
+    render(element);
+
+    expect(commits[0]).toBe('timeline');
+  });
+
+  // The guard above only suppresses the empty state while a load is outstanding. Without
+  // this case, a regression that left isLoading permanently true would show an endless
+  // spinner to every user who has no moods, and the two tests above would still pass.
+  it('still reaches the empty state once a load resolves with no moods', async () => {
+    mockedGetMoodHistory.mockResolvedValue([]);
+
+    render(<MoodHistoryTimeline userId={USER_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-mood-history-state')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/useMoodHistory.ts
+++ b/src/hooks/useMoodHistory.ts
@@ -44,7 +44,10 @@ interface UseMoodHistoryReturn {
  */
 export function useMoodHistory(userId: string): UseMoodHistoryReturn {
   const [moods, setMoods] = useState<SupabaseMood[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Starts true because the mount effect below fetches unconditionally. Initialising it
+  // false meant the first commit reported "settled with zero results" for a load that had
+  // not been issued yet, since the effect is passive and runs after that commit.
+  const [isLoading, setIsLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
   const [offset, setOffset] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -69,12 +72,13 @@ export function useMoodHistory(userId: string): UseMoodHistoryReturn {
   }, [userId]);
 
   useEffect(() => {
-    // The synchronous setIsLoading(true)/setError(null) inside loadInitialMoods is the point,
-    // not an oversight: the timeline has to paint its skeleton on the render right after mount
-    // instead of sitting on a stale empty state for a network round trip. loadInitialMoods is
-    // also the exposed `retry`, so the kickoff cannot move out of it, and a paginated fetch
-    // accumulating pages in local state has nothing to derive during render and no external
-    // store to subscribe to.
+    // The synchronous setIsLoading(true)/setError(null) inside loadInitialMoods does nothing
+    // for the mount path — isLoading already starts true, and the effect runs after paint, so
+    // it could never have beaten the first commit to the screen. It earns its place on the
+    // retry path instead: loadInitialMoods is the exposed `retry`, where it clears the failure
+    // banner and re-enters the spinner from a settled state. The suppression stands because a
+    // paginated fetch accumulating pages in local state has nothing to derive during render
+    // and no external store to subscribe to.
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch-on-mount lifecycle
     loadInitialMoods();
   }, [loadInitialMoods]);


### PR DESCRIPTION
## What

Promotes `react-hooks/set-state-in-effect` and `react-hooks/purity` from `warn` to `error`, promotes unused disable directives to `error`, and fixes one real defect the audit surfaced.

## Why the promotion is not cosmetic

Both rules are already `error` in `eslint-plugin-react-hooks`' own recommended config — the two lines in `eslint.config.js` were an explicit **downgrade**, not a promotion above default.

More importantly, `.github/workflows/test.yml:100` runs `npm run lint`, and neither the script nor CI passes `--max-warnings`. ESLint exits 0 on warnings. **At `warn`, these two rules could never fail CI** — they were advisory only.

Verified with throwaway canaries (all removed) that the promotion actually bites:

| Canary | Result |
|---|---|
| `setState` in a `useEffect` | `error … react-hooks/set-state-in-effect` |
| `Date.now()` during render | `error  Cannot call impure function during render` |
| directive suppressing nothing | `error  Unused eslint-disable directive` |

`new Date()` during render is still **not** flagged — confirmed separately, and already documented in place at `src/components/MoodTracker/MoodTracker.tsx:159`.

## Unused disable directives

A directive is a written exemption, so a dead one is a false claim about the code. They defaulted to `warn`, which with no `--max-warnings` meant CI ignored them — that is how the stale suppressions cleaned up in 2226cc01 and e9d41bad accumulated. Now `error`.

## The defect

The promotion by itself changed no findings: lint was 0/0 before and after, because 13 `set-state-in-effect` directives absorb it (`purity` has zero). So each suppression was audited. One turned out to be documenting a bug, and the comment was mine from #247.

`useMoodHistory` initialised `isLoading` to `false`. `MoodHistoryTimeline.tsx:228` picks between spinner and empty state with `!isLoading && moods.length === 0`, and the fetch is kicked off from a **passive** effect — which runs *after* that commit. So the mount commit rendered "no mood history yet": a settled, zero-result answer for a request that had not been issued.

Measured with `Profiler.onRender`, which fires after DOM mutation:

```
before: ["empty-state", "timeline", "timeline", "timeline"]
after:  ["timeline", "timeline", "timeline"]
```

One fewer commit, and no wrong terminal state.

The old comment asserted the opposite — that the synchronous `setIsLoading(true)` inside `loadInitialMoods` was what painted the skeleton at mount. It never could. It *does* earn its place on the retry path, so the call and its suppression stay and the comment now says why.

**Not claimed:** that a user saw this. The panel mounts inside an `AnimatePresence` fade from `opacity: 0`, so the offending commit may well have painted invisibly. The commit sequence is what was measured, so it is what the test asserts.

## Tests

Three new cases driving the **real** hook with only the network layer mocked, so every asserted state is reachable in production — deliberately not the mistake made in #247, where a deleted test asserted on a hand-built store state the real store could never produce. Red against the unfixed hook (`expected [ 'empty-state', … ] to not include 'empty-state'`), green with it.

The third case covers the empty state resolving with zero moods. Nothing covered it before, and it is the case a stuck spinner would regress silently while the other two kept passing.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | 0 errors, 0 warnings |
| `npm run typecheck` | clean |
| `npm run test:unit` | 1087 passed, 74 files |

## Audit findings not in this PR

Auditing all 13 suppressions surfaced three further defects behind directives whose rationales overstate their case. They are **not** lint fallout — lint is 0 with or without them — and each is a behavioural change deserving its own review, so they are listed rather than bundled:

1. **`MoodHistoryCalendar.tsx:123`** — the month load writes results with no cancellation or identity guard, so a read resolving after the user changes month can paint the previous month's data.
2. **`useScripturePresence.ts:286`** — a partner `presence_update` arriving between commit and the passive-effect flush is clobbered by the step-change reset.
3. **`useNetworkStatus.ts:100`** — a redundant `online` event while already online yields `isOnline=true, isConnecting=true`, showing a spurious "Connecting…". The effect also re-subscribes its listener pair on every `isOnline` change.

Two further proposals were **rejected** as inert — `Countdown.tsx:49` and `usePartnerMood.ts:49` would only satisfy the linter, with no reachable behaviour change.

Also noted, pre-existing and untouched: `react-window-infinite-loader`'s in-flight dedupe `Set` is memoised on callbacks that `MoodHistoryTimeline.tsx:171,174` recreate every render, so it is discarded each render and cannot suppress a repeat load. `loadMore`'s own `if (isLoading || !hasMore) return;` masks it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019osXWtUvDhKDB13h1wFA5X
