### PR TITLE
fix(db): close the anon-executable function surface and four authorization holes

### DIFF
--- a/supabase/migrations/20260818000000_revoke_anon_execute_and_fix_partner_guards.sql
+++ b/supabase/migrations/20260818000000_revoke_anon_execute_and_fix_partner_guards.sql
@@ -1,0 +1,370 @@
+-- ============================================
+-- Migration: Close the anon-executable SECURITY DEFINER surface
+-- Created: 2026-08-17
+--
+-- Fixes Supabase advisor lints 0028 (anon_security_definer_function_executable)
+-- and 0029 (authenticated_security_definer_function_executable), which fired on
+-- the nine SECURITY DEFINER functions in `public` plus one that exists only on
+-- the hosted project (see the note on drift below).
+--
+-- Three of those warnings were not cosmetic. Verified against the local stack.
+--
+-- 1. accept_partner_request -- unauthenticated forced partner link (critical)
+-- --------------------------------------------------------------------------
+-- The recipient check was written as:
+--
+--     IF auth.uid() != v_to_user_id THEN
+--       RAISE EXCEPTION 'Only the recipient can accept a partner request';
+--     END IF;
+--
+-- For an anonymous caller auth.uid() is NULL, so `NULL != v_to_user_id` is NULL,
+-- and plpgsql treats a NULL condition as false. The RAISE never fires and both
+-- `UPDATE users SET partner_id` statements run as the definer, bypassing RLS.
+--
+-- Demonstrated end to end: an attacker signs up, sends a partner request to a
+-- victim (permitted -- the INSERT policy only requires auth.uid() = from_user_id),
+-- then replays the accept RPC with the Authorization header removed. The link is
+-- created without the victim ever seeing the request. Holding partner_id then
+-- grants SELECT on the victim's `users` row, every `moods` row and note, every
+-- `photos` row, and the underlying `storage.objects` in the `photos` and
+-- `love-notes-images` buckets.
+--
+-- It is also unrecoverable for the victim: `users_update_self_safe` forbids
+-- clearing your own partner_id, and there is no unlink RPC.
+--
+-- 2. decline_partner_request -- same NULL-poisoned guard (medium)
+-- --------------------------------------------------------------
+-- Identical shape. An unauthenticated caller who knows a request id can kill a
+-- pending link. Bounded by the id being unguessable and unreadable to anon, but
+-- the sender knows their own id and is explicitly not supposed to decline.
+--
+-- 3. scripture_seed_test_data -- test seeder on the public API (critical)
+-- ----------------------------------------------------------------------
+-- Reachable by anon and by every signed-in user. Its only production guard is
+-- `current_setting('app.environment', true) = 'production'`, and that GUC is set
+-- nowhere -- not in config.toml, not in CI, not in any migration, and not on the
+-- hosted project -- so it returns NULL and the guard never fires anywhere.
+-- Since 20260725180000 the function takes explicit p_user1_id / p_user2_id and
+-- only checks that those users exist, never that the caller owns them. Passing
+-- p_user1_id = victim, p_user2_id = self mints a `together` session whose
+-- user2_id is the attacker, and the scripture_sessions policies key on
+-- `user1_id = auth.uid() OR user2_id = auth.uid()` -- a forced pairing that
+-- skips the partner_requests flow entirely. p_session_count is unvalidated too.
+--
+-- The remaining six were verified non-exploitable BY ANON and are tightened here
+-- only as defense in depth: get_my_partner_id, is_scripture_session_member,
+-- scripture_get_couple_stats and scripture_submit_reflection return nothing to a
+-- NULL auth.uid(); scripture_create_session has a real `IS NULL` guard;
+-- sync_user_profile RETURNS trigger so PostgREST cannot invoke it.
+--
+-- "Non-exploitable by anon" is the whole claim. scripture_create_session in
+-- particular still lets any signed-in user open a `together` session naming any
+-- other user id, with no partner link and no consent -- that is a separate
+-- authenticated-user bug, out of scope here, not something this migration fixes.
+--
+-- Why the revoke is written the way it is
+-- ---------------------------------------
+-- `REVOKE ... FROM anon` alone is a no-op on the local stack: proacl there is
+-- NULL or `{=X/postgres,...}`, i.e. the privilege is held by PUBLIC, and an ACL
+-- check is a union with no deny entry. PUBLIC is the grantee that matters. The
+-- hosted project additionally carries an explicit `anon=X/postgres` from its own
+-- `pg_default_acl` row (postgres | public | f), so both must be revoked to cover
+-- both environments.
+--
+-- Revoking PUBLIC also removes the implicit grant that `authenticated` and
+-- `service_role` were riding on. Four functions never had an explicit grant
+-- (accept_partner_request, decline_partner_request, is_scripture_session_member,
+-- scripture_seed_test_data -- the last lost its 20260128000001 grant when
+-- 20260309000001 and 20260725180000 dropped and recreated it), so they are
+-- granted explicitly below. Without that, revoking PUBLIC would 42501 the
+-- partner accept/decline buttons and every scripture read, because the nine RLS
+-- policies on scripture_step_states, scripture_reflections, scripture_bookmarks
+-- and scripture_messages call is_scripture_session_member and are declared TO
+-- public, so the function executes as the invoking role.
+--
+-- The revoke loops over pg_proc rather than naming functions, because the hosted
+-- project has one function this repo does not: get_random_daily_message(text).
+-- No migration creates it and nothing in src/ or tests/ calls it, so it is drift
+-- rather than a dependency, but naming it explicitly would abort this migration
+-- with 42883 on every environment that does not have it.
+--
+-- HOW THIS REGRESSES, AND WHY THERE IS NO PREVENTION HERE
+-- ------------------------------------------------------
+-- A plain REVOKE survives CREATE OR REPLACE and unrelated later DDL, but
+-- DROP FUNCTION + CREATE FUNCTION creates a new object that re-derives its ACL
+-- from scratch and lands anon-executable again. This repo already drops and
+-- recreates functions in three migrations, so this is a live risk, not a
+-- theoretical one.
+--
+-- The obvious guard does not work. Measured on PostgreSQL 17.6:
+--
+--   alter default privileges for role postgres in schema public
+--     revoke execute on functions from anon, public;
+--
+-- is a no-op. PUBLIC's EXECUTE on a new function comes from the hardwired
+-- acldefault(), not from a pg_default_acl row, and a schema-scoped entry is
+-- merged onto that default with add-only semantics -- it can grant more, never
+-- subtract. After running the statement above, the stored row reads
+-- `{postgres=X/postgres}` and a freshly created function still reports
+-- has_function_privilege('anon', ..., 'EXECUTE') = true.
+--
+-- The global form (same statement without `IN SCHEMA public`) does work, but it
+-- strips PUBLIC EXECUTE from every schema this role creates functions in, which
+-- breaks the `tests.*` helpers that each pgTAP file defines inline -- verified:
+-- the suite drops from 158 passing to 108 with it applied. Not worth it.
+--
+-- So this migration does not prevent the regression; it detects it.
+-- supabase/tests/database/18_function_execute_grants.sql enumerates every
+-- function in `public` and fails if any of them becomes anon-executable, and
+-- `supabase test db` runs in CI. A future DROP+CREATE goes red there.
+--
+-- NOTE FOR FUTURE MIGRATIONS: if you DROP and CREATE a function in `public`,
+-- re-apply its REVOKE and its GRANT in the same migration. CREATE OR REPLACE is
+-- safe and preserves the ACL.
+-- ============================================
+
+begin;
+
+-- ============================================
+-- 1. accept_partner_request: deny a NULL auth.uid() explicitly
+-- ============================================
+-- Body is unchanged from 20251206024345 apart from the guard.
+create or replace function public.accept_partner_request(p_request_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'public', 'pg_catalog'
+as $function$
+  DECLARE
+    v_caller_id UUID;
+    v_from_user_id UUID;
+    v_to_user_id UUID;
+    v_request_status TEXT;
+  BEGIN
+    v_caller_id := auth.uid();
+
+    IF v_caller_id IS NULL THEN
+      RAISE EXCEPTION 'Authentication required';
+    END IF;
+
+    SELECT from_user_id, to_user_id, status
+    INTO v_from_user_id, v_to_user_id, v_request_status
+    FROM partner_requests
+    WHERE id = p_request_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Partner request not found';
+    END IF;
+
+    IF v_request_status != 'pending' THEN
+      RAISE EXCEPTION 'Partner request is not pending';
+    END IF;
+
+    -- IS DISTINCT FROM, not !=: a NULL on either side must deny, not fall
+    -- through. v_to_user_id is NOT NULL in practice, but the operator makes the
+    -- guard correct regardless of which side is NULL.
+    IF v_caller_id IS DISTINCT FROM v_to_user_id THEN
+      RAISE EXCEPTION 'Only the recipient can accept a partner request';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM users
+      WHERE id IN (v_from_user_id, v_to_user_id)
+      AND partner_id IS NOT NULL
+    ) THEN
+      RAISE EXCEPTION 'One or both users already have a partner';
+    END IF;
+
+    UPDATE users SET partner_id = v_to_user_id, updated_at = now()
+    WHERE id = v_from_user_id;
+
+    UPDATE users SET partner_id = v_from_user_id, updated_at = now()
+    WHERE id = v_to_user_id;
+
+    UPDATE partner_requests
+    SET status = 'accepted', updated_at = now()
+    WHERE id = p_request_id;
+
+    UPDATE partner_requests
+    SET status = 'declined', updated_at = now()
+    WHERE id != p_request_id
+      AND status = 'pending'
+      AND (from_user_id IN (v_from_user_id, v_to_user_id)
+           OR to_user_id IN (v_from_user_id, v_to_user_id));
+  END;
+  $function$;
+
+-- ============================================
+-- 2. decline_partner_request: same fix
+-- ============================================
+create or replace function public.decline_partner_request(p_request_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'public', 'pg_catalog'
+as $function$
+  DECLARE
+    v_caller_id UUID;
+    v_to_user_id UUID;
+  BEGIN
+    v_caller_id := auth.uid();
+
+    IF v_caller_id IS NULL THEN
+      RAISE EXCEPTION 'Authentication required';
+    END IF;
+
+    SELECT to_user_id
+    INTO v_to_user_id
+    FROM partner_requests
+    WHERE id = p_request_id AND status = 'pending';
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Partner request not found or already processed';
+    END IF;
+
+    IF v_caller_id IS DISTINCT FROM v_to_user_id THEN
+      RAISE EXCEPTION 'Only the recipient can decline a partner request';
+    END IF;
+
+    UPDATE partner_requests
+    SET status = 'declined', updated_at = now()
+    WHERE id = p_request_id;
+  END;
+  $function$;
+
+-- ============================================
+-- 3. Drop anon/PUBLIC execute across public
+-- ============================================
+-- Extension-owned routines are skipped so this never touches objects the repo
+-- does not own; today `public` holds only the 15 application functions, because
+-- pgtap and friends are installed into `extensions`.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select p.oid::regprocedure as routine
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prokind in ('f', 'p')
+      and not exists (
+        select 1 from pg_depend d
+        where d.objid = p.oid and d.deptype = 'e'
+      )
+  loop
+    execute format('revoke execute on routine %s from anon', r.routine);
+    execute format('revoke execute on routine %s from public', r.routine);
+  end loop;
+end;
+$$;
+
+-- ============================================
+-- 4. Restore the grants the app actually needs
+-- ============================================
+-- These four rode on PUBLIC's implicit grant and would 42501 without this.
+grant execute on function public.accept_partner_request(uuid) to authenticated;
+grant execute on function public.decline_partner_request(uuid) to authenticated;
+
+-- Required by the nine RLS policies that call it (they are declared TO public,
+-- so the function runs as the invoking role, not as the policy owner).
+grant execute on function public.is_scripture_session_member(uuid) to authenticated;
+
+-- Test seeder: service_role only. tests/support/factories/index.ts:147 calls it
+-- through the admin client, which is the only caller in the repo. It is
+-- deliberately NOT granted to authenticated -- that is lint 0029, and the whole
+-- point is that a signed-in user must not be able to seed rows into someone
+-- else's account.
+grant execute on function public.scripture_seed_test_data(int, boolean, boolean, text, int[], uuid, uuid)
+  to service_role;
+
+-- The remaining app functions already carry an explicit `authenticated` grant
+-- from their own migrations, which step 3 left untouched. Re-stated here so a
+-- reader can see the intended end state in one place, and so the local stack
+-- matches the hosted project where the platform default ACL had granted them.
+grant execute on function public.get_my_partner_id() to authenticated;
+grant execute on function public.scripture_create_session(text, uuid) to authenticated;
+grant execute on function public.scripture_get_couple_stats() to authenticated;
+grant execute on function public.scripture_submit_reflection(uuid, int, int, text, boolean) to authenticated;
+grant execute on function public.scripture_select_role(uuid, text) to authenticated;
+grant execute on function public.scripture_toggle_ready(uuid, boolean) to authenticated;
+grant execute on function public.scripture_convert_to_solo(uuid) to authenticated;
+grant execute on function public.scripture_lock_in(uuid, int, int) to authenticated;
+grant execute on function public.scripture_undo_lock_in(uuid, int) to authenticated;
+grant execute on function public.scripture_end_session(uuid) to authenticated;
+
+-- ============================================
+-- 4b. Revoke from `authenticated` where the grant is explicit, not implicit
+-- ============================================
+-- Step 3 only removes anon and PUBLIC, which is enough on a local stack: there,
+-- `authenticated` reaches these two purely through PUBLIC, so revoking PUBLIC
+-- takes it away as a side effect.
+--
+-- The hosted project is NOT shaped like that. Its pg_default_acl carries
+--
+--   postgres | public | f | {postgres=X/postgres,anon=X/postgres,
+--                            authenticated=X/postgres,service_role=X/postgres}
+--
+-- so every function there holds a SEPARATE, explicit `authenticated=X` entry
+-- that survives revoking PUBLIC. Verified after applying steps 1-4 to
+-- xojempkrugifnaveqtqc: anon was correctly false everywhere, but
+-- scripture_seed_test_data still reported authenticated = true -- lint 0029 was
+-- still firing and the seeder was still reachable by every signed-in user, which
+-- is the whole point of locking it down. These two revokes are what actually
+-- close it on hosted; on local they are harmless no-ops.
+revoke execute on function public.scripture_seed_test_data(int, boolean, boolean, text, int[], uuid, uuid)
+  from authenticated;
+
+-- sync_user_profile is intentionally callable by nobody. It RETURNS trigger, so
+-- PostgREST cannot expose it, and Postgres checks EXECUTE on a trigger function
+-- at CREATE TRIGGER time rather than at fire time, so on_auth_user_created keeps
+-- working with no grant at all.
+revoke execute on function public.sync_user_profile() from authenticated, service_role;
+
+-- Not touched: service_role's explicit grants on the remaining functions, which
+-- exist on hosted and not on local. service_role is the trusted secret key, the
+-- advisor lints do not cover it, and broad service_role access is Supabase's
+-- normal posture -- so this migration deliberately does not try to make the two
+-- environments byte-identical there. anon and authenticated, which are what the
+-- lints and the threat model care about, ARE identical on both after this runs.
+
+-- service_role is also deliberately not re-granted on anything but the seeder.
+-- It rode on PUBLIC before this migration and nothing in the repo needs it:
+-- scripture_seed_test_data is the only RPC called through the admin client
+-- (tests/support/factories/index.ts:147), and service_role has BYPASSRLS, so it
+-- never evaluates a policy that would call is_scripture_session_member. A future
+-- Edge Function that calls an RPC server-side needs its own explicit grant.
+
+-- ============================================
+-- 5. Close the same hole one layer up: direct UPDATE on partner_requests
+-- ============================================
+-- Fixing the NULL guard above stops an ANONYMOUS caller from forging a partner
+-- link. It does not stop a SIGNED-IN one, because accept_partner_request trusts
+-- the row it reads, and the row was writable by the attacker:
+--
+--   policy "Users can update received requests" ON partner_requests
+--     FOR UPDATE USING ((SELECT auth.uid()) = to_user_id)
+--
+-- had no WITH CHECK, and Postgres reuses USING for the check when WITH CHECK is
+-- absent. That constrains only to_user_id, leaving from_user_id and status
+-- unconstrained. So the recipient of any request can rewrite from_user_id to an
+-- arbitrary victim and then accept it legitimately -- the caller really is
+-- to_user_id, so the repaired guard passes. Verified end to end: attacker gets a
+-- burner account to send them a request, PATCHes from_user_id to the victim,
+-- accepts, and reads the victim's moods and profile. Same irreversible link, one
+-- free signup instead of none.
+--
+-- A WITH CHECK cannot express the rule, because RLS check expressions cannot see
+-- OLD -- there is no way to say "from_user_id must not change". The write path is
+-- unnecessary anyway: the app never UPDATEs this table (src/api/partnerService.ts
+-- inserts at :184 and selects at :222; accept and decline go through the two
+-- SECURITY DEFINER RPCs), so the fix is to remove the path rather than fence it.
+--
+-- Both RPCs keep working: they are SECURITY DEFINER, so their UPDATEs are
+-- checked against the owner, not the caller. No pgTAP `policies_are` array
+-- covers partner_requests, so nothing in supabase/tests/database needs editing.
+drop policy if exists "Users can update received requests" on public.partner_requests;
+
+revoke update on public.partner_requests from anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
+++ b/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
@@ -208,6 +208,15 @@ drop policy if exists scripture_sessions_insert on public.scripture_sessions;
 -- get_my_partner_id" instead of a clean row-level-security denial. Both refuse
 -- the write; scoping the policy keeps the error honest and drops the dependency
 -- on anon's grants.
+--
+-- Knowingly NOT applied to the nine TO public policies from 20260128000001 that
+-- call is_scripture_session_member, which anon likewise no longer holds EXECUTE
+-- on, so anon still gets the function error on those tables. The reasoning is
+-- the same but the cost is not: this policy was being rewritten anyway, whereas
+-- re-declaring nine otherwise-untouched policies across four tables to change an
+-- error message that no app or test path can reach unauthenticated is churn with
+-- no security gain. Both forms deny. If those policies are rewritten for another
+-- reason, add `to authenticated` then.
 create policy scripture_sessions_insert on public.scripture_sessions
   for insert
   to authenticated
@@ -251,11 +260,21 @@ create policy scripture_sessions_insert on public.scripture_sessions
 -- so the empty path costs nothing.
 --
 -- The trigger is unconditional: row triggers are not skipped for table owners or
--- BYPASSRLS roles, so this also blocks postgres and service_role. Nothing in the
--- repo writes these columns, but a future migration that legitimately needs to
--- repoint membership must wrap its UPDATE in
+-- BYPASSRLS roles, so this also blocks postgres and service_role. A future
+-- migration that legitimately needs to repoint membership must wrap its UPDATE in
 --   alter table public.scripture_sessions disable trigger scripture_sessions_freeze_membership;
 --   ... ; alter table public.scripture_sessions enable trigger ...;
+--
+-- One existing writer, and it is worth knowing about: tests/support/helpers/
+-- scripture-overview.ts:74-79 (adoptSessionForBrowserUser) issues
+-- `supabaseAdmin.from('scripture_sessions').update({ user1_id: browserUserId })`
+-- on the paths used by scripture-reflection-2.2, 2.2-errors and 2.3. It passes
+-- only because it is now a no-op: tests/support/factories/index.ts:140-144 seeds
+-- onto the same worker user the browser is signed in as, and `is distinct from`
+-- lets an unchanged value through. Verified both ways -- same id updates fine,
+-- a different id raises 42501. If those ids ever diverge that helper fails loudly
+-- instead of silently reassigning, which is the intended outcome; the helper
+-- carries a note saying so.
 create or replace function public.scripture_sessions_freeze_membership()
 returns trigger
 language plpgsql

--- a/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
+++ b/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
@@ -1,0 +1,614 @@
+-- ============================================
+-- Migration: Stop forced `together` pairings, and give the test seeder a guard
+--            that actually fires
+-- Created: 2026-08-17
+--
+-- Two follow-ups to 20260818000000, which closed the anon-executable surface.
+-- Neither of these is reachable by an anonymous caller, so no advisor lint flags
+-- them; both are reachable by any signed-in user.
+--
+-- 1. Forced `together` sessions
+-- ----------------------------
+-- scripture_create_session validated p_partner_id only as
+--
+--     if not exists (select 1 from auth.users where id = p_partner_id)
+--
+-- i.e. "is this a real account", never "is this MY partner". Any signed-in user
+-- could therefore name any other user by id and open a `together` session with
+-- them. Both rows then satisfy is_scripture_session_member, and
+-- scripture_messages_select is keyed on exactly that, so the attacker gets a
+-- two-way message channel with a stranger plus SELECT/UPDATE on the session --
+-- bypassing the partner_requests flow entirely.
+--
+-- Fixing the RPC alone would have been cosmetic. `authenticated` holds a direct
+-- INSERT grant on scripture_sessions and the insert policy read
+--
+--     with check (user1_id = auth.uid())
+--
+-- which constrains only user1_id. Verified: a client can skip the RPC, INSERT a
+-- `together` row naming any victim as user2_id, and the victim immediately
+-- returns true from is_scripture_session_member. So the policy is tightened in
+-- the same migration. Its NAME is unchanged, so the `policies_are` array in
+-- supabase/tests/database/02_rls_policies.sql:70-73 still matches and needs no
+-- edit.
+--
+-- Sessions forced before this migration are cleaned up below.
+--
+-- 2. The seeder's guard that never fired
+-- --------------------------------------
+-- scripture_seed_test_data's only in-body protection was
+--
+--     if current_setting('app.environment', true) = 'production' then raise
+--
+-- and `app.environment` is set in no environment -- not supabase/config.toml,
+-- not .github/, not any migration, and not on the hosted project -- so
+-- current_setting returned NULL and the branch was dead everywhere, production
+-- included. 20260818000000 already revoked EXECUTE from anon and authenticated,
+-- so the hole is closed by the grant today; this replaces the dead branch so
+-- that a future DROP FUNCTION + CREATE FUNCTION (which resets the ACL and
+-- re-grants PUBLIC, and which this repo has already done twice to this very
+-- function) does not silently reopen arbitrary cross-account seeding.
+--
+-- The obvious guard does not work: inside a SECURITY DEFINER function
+-- `current_user` is the OWNER, so it reads 'postgres' for attacker and admin
+-- alike. Measured. The `role` GUC is not rewritten by SECURITY DEFINER and still
+-- reports the role PostgREST switched to, so that is what the new guard reads.
+--
+-- Rejected alternative: setting app.environment properly via
+-- `ALTER DATABASE ... SET` in supabase/seed.sql. `postgres` is not superuser on
+-- Supabase and the statement fails with "permission denied to set parameter",
+-- seed.sql never runs against a remote project anyway, and ALTER DATABASE does
+-- not reach PostgREST's already-open connections.
+--
+-- Both functions use CREATE OR REPLACE, never DROP: a DROP would reset proacl
+-- and undo 20260818000000's revokes.
+-- ============================================
+
+begin;
+
+-- ============================================
+-- 1a. scripture_create_session: require the caller's real partner
+-- ============================================
+-- Body is unchanged from the live definition apart from the guard noted inline.
+CREATE OR REPLACE FUNCTION public.scripture_create_session(p_mode text, p_partner_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+declare
+  v_user_id uuid;
+  v_session_id uuid;
+  v_result jsonb;
+  v_start_phase public.scripture_session_phase;
+begin
+  v_user_id := (select auth.uid());
+
+  if v_user_id is null then
+    raise exception 'Authentication required.';
+  end if;
+
+  if p_mode not in ('solo', 'together') then
+    raise exception 'Invalid mode: %. Must be solo or together.', p_mode;
+  end if;
+
+  if p_mode = 'together' and p_partner_id is null then
+    raise exception 'Partner ID is required for together mode.';
+  end if;
+
+  if p_mode = 'together' then
+    if p_partner_id = v_user_id then
+      raise exception 'Partner cannot be the current user.';
+    end if;
+
+    -- Only the caller's own linked partner. p_partner_id arrives from the client
+    -- and used to be validated only as "is some auth.users row", which let any
+    -- signed-in user open a `together` session naming a stranger -- both sides
+    -- then satisfy is_scripture_session_member, which is a two-way
+    -- scripture_messages channel the victim never agreed to.
+    --
+    -- IS DISTINCT FROM, not <>: an unpartnered caller reads NULL here and must be
+    -- denied rather than fall through a NULL comparison.
+    --
+    -- This sits BEFORE the reuse lookup below on purpose. Behind it, a session
+    -- forced before this migration would still be handed back by the reuse
+    -- branch, reopening the same channel.
+    --
+    -- public. qualification is required: this function is SET search_path TO ''.
+    if p_partner_id is distinct from public.get_my_partner_id() then
+      raise exception 'Together mode requires your linked partner.'
+        using errcode = '42501';
+    end if;
+
+    -- Reuse existing in-progress together session for this exact pair (any user order).
+    -- Only reuse sessions still in lobby phase — sessions that have progressed
+    -- past lobby (reading, reflection, etc.) should not be reused.
+    select s.id
+      into v_session_id
+      from public.scripture_sessions s
+      where s.mode = 'together'
+        and s.status = 'in_progress'
+        and s.current_phase = 'lobby'
+        and (
+          (s.user1_id = v_user_id and s.user2_id = p_partner_id)
+          or
+          (s.user1_id = p_partner_id and s.user2_id = v_user_id)
+        )
+      order by s.started_at desc
+      limit 1;
+  end if;
+
+  if v_session_id is null then
+    v_start_phase := case
+      when p_mode = 'together' then 'lobby'::public.scripture_session_phase
+      else 'reading'::public.scripture_session_phase
+    end;
+
+    insert into public.scripture_sessions (
+      mode,
+      user1_id,
+      user2_id,
+      current_phase,
+      current_step_index,
+      status,
+      version,
+      started_at
+    ) values (
+      p_mode::public.scripture_session_mode,
+      v_user_id,
+      case when p_mode = 'together' then p_partner_id else null end,
+      v_start_phase,
+      0,
+      'in_progress'::public.scripture_session_status,
+      1,
+      now()
+    )
+    returning id into v_session_id;
+  end if;
+
+  select jsonb_build_object(
+    'id', s.id,
+    'mode', s.mode,
+    'user1_id', s.user1_id,
+    'user2_id', s.user2_id,
+    'current_phase', s.current_phase,
+    'current_step_index', s.current_step_index,
+    'status', s.status,
+    'version', s.version,
+    'started_at', s.started_at,
+    'completed_at', s.completed_at
+  )
+    into v_result
+    from public.scripture_sessions s
+    where s.id = v_session_id;
+
+  return v_result;
+end;
+$function$;
+
+-- ============================================
+-- 1b. Close the direct-INSERT path that bypasses the RPC entirely
+-- ============================================
+-- Same policy name as before, so the policies_are array in
+-- supabase/tests/database/02_rls_policies.sql still matches.
+-- `user2_id is null` covers solo sessions.
+drop policy if exists scripture_sessions_insert on public.scripture_sessions;
+
+-- `to authenticated`, not the previous implicit PUBLIC: the check calls
+-- get_my_partner_id(), on which anon holds no EXECUTE since 20260818000000, so a
+-- PUBLIC policy makes an anon INSERT fail with "permission denied for function
+-- get_my_partner_id" instead of a clean row-level-security denial. Both refuse
+-- the write; scoping the policy keeps the error honest and drops the dependency
+-- on anon's grants.
+create policy scripture_sessions_insert on public.scripture_sessions
+  for insert
+  to authenticated
+  with check (
+    user1_id = (select auth.uid())
+    and (
+      user2_id is null
+      or user2_id = public.get_my_partner_id()
+    )
+  );
+
+-- ============================================
+-- 1c. Close the UPDATE path, which the INSERT policy does not cover
+-- ============================================
+-- scripture_sessions_update is
+--
+--     using ((user1_id = auth.uid()) or (user2_id = auth.uid()))
+--
+-- with no WITH CHECK, so Postgres reuses USING as the check -- the same shape as
+-- the partner_requests bug fixed in 20260818000000. Verified: an attacker creates
+-- a SOLO session (no partner required), then UPDATEs it to
+-- `mode = 'together', user2_id = <victim>`. USING still passes because they are
+-- still user1_id, and the victim immediately returns true from
+-- is_scripture_session_member. Tightening only the INSERT policy left this open.
+--
+-- A WITH CHECK cannot express the rule: it cannot see OLD, so it cannot say
+-- "user2_id must not change". Stating it as a value constraint instead --
+-- "user2_id must be the pair's partner" -- would also strand a legitimate
+-- in-flight session the moment a couple unlinks, because every later phase/step
+-- UPDATE would start failing the check. A BEFORE UPDATE trigger says exactly
+-- what is meant and nothing more.
+--
+-- user2_id is allowed to become NULL because scripture_convert_to_solo does
+-- precisely that (`set mode = 'solo', user2_id = null`). What is forbidden is
+-- moving it to a NEW non-null value, which is the only shape the attack needs.
+-- SECURITY INVOKER, which keeps it off the SECURITY DEFINER advisor surface
+-- entirely (lints 0028/0029). search_path is still pinned: lint 0011
+-- (function_search_path_mutable) applies to every function, not only definer
+-- ones, and this repo already has a migration dedicated to that class
+-- (20260221000001_fix_function_search_paths.sql). The body references no object,
+-- so the empty path costs nothing.
+--
+-- The trigger is unconditional: row triggers are not skipped for table owners or
+-- BYPASSRLS roles, so this also blocks postgres and service_role. Nothing in the
+-- repo writes these columns, but a future migration that legitimately needs to
+-- repoint membership must wrap its UPDATE in
+--   alter table public.scripture_sessions disable trigger scripture_sessions_freeze_membership;
+--   ... ; alter table public.scripture_sessions enable trigger ...;
+create or replace function public.scripture_sessions_freeze_membership()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+begin
+  if new.user1_id is distinct from old.user1_id then
+    raise exception 'scripture_sessions.user1_id is immutable'
+      using errcode = '42501';
+  end if;
+
+  -- Unchanged, or cleared by scripture_convert_to_solo. Never repointed.
+  if new.user2_id is distinct from old.user2_id and new.user2_id is not null then
+    raise exception 'scripture_sessions.user2_id cannot be reassigned'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$function$;
+
+-- A new function in `public` is created with PostgreSQL's built-in default of
+-- EXECUTE to PUBLIC, which 20260818000000 could not prevent for future functions
+-- (see its header). Left alone this one would be anon-executable and both advisor
+-- lints would fire again. Caught by FN-GRANT-002 in
+-- supabase/tests/database/18_function_execute_grants.sql, which is exactly the
+-- regression net that migration says it is.
+--
+-- Nobody needs EXECUTE: Postgres checks a trigger function's EXECUTE privilege at
+-- CREATE TRIGGER time, not at fire time, so the trigger below keeps working with
+-- no grant at all -- same as sync_user_profile.
+revoke execute on function public.scripture_sessions_freeze_membership()
+  from anon, authenticated, service_role, public;
+
+drop trigger if exists scripture_sessions_freeze_membership on public.scripture_sessions;
+
+create trigger scripture_sessions_freeze_membership
+  before update on public.scripture_sessions
+  for each row
+  execute function public.scripture_sessions_freeze_membership();
+
+-- ============================================
+-- 1d. Close the same missing-WITH-CHECK shape on the child tables
+-- ============================================
+-- scripture_reflections_insert and scripture_bookmarks_insert both check
+-- `is_scripture_session_member(session_id)`. Their UPDATE counterparts check only
+-- `user_id = auth.uid()` and, having no WITH CHECK, reuse that as the check -- so
+-- session_id is unconstrained on update. Verified: an attacker writes a
+-- reflection in their own session, then repoints it with
+-- `update ... set session_id = <victim session>`, and the victim reads
+-- attacker-authored text inside their own private session.
+--
+-- Names are unchanged, so the policies_are arrays in
+-- supabase/tests/database/02_rls_policies.sql:80-89 still match.
+--
+-- scripture_step_states_update already uses is_scripture_session_member as its
+-- USING clause, so its implicit check is sound and it is left alone.
+-- scripture_messages has no UPDATE policy at all.
+drop policy if exists scripture_reflections_update on public.scripture_reflections;
+
+create policy scripture_reflections_update on public.scripture_reflections
+  for update
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (
+    user_id = (select auth.uid())
+    and public.is_scripture_session_member(session_id)
+  );
+
+drop policy if exists scripture_bookmarks_update on public.scripture_bookmarks;
+
+create policy scripture_bookmarks_update on public.scripture_bookmarks
+  for update
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (
+    user_id = (select auth.uid())
+    and public.is_scripture_session_member(session_id)
+  );
+
+-- ============================================
+-- 1e. No cleanup of pre-existing forced sessions -- deliberately
+-- ============================================
+-- An earlier draft deleted `together` sessions whose two users are not mutually
+-- linked. That predicate is not safe, because it cannot tell a forced session
+-- from a legitimate one belonging to a couple who has since unlinked: membership
+-- is keyed on user ids only (is_scripture_session_member reads neither mode nor
+-- status nor partner_id), so an ordinary break-up produces exactly the same row
+-- shape as an attack. Deleting on that signal would destroy real in-progress
+-- sessions, and the delete cascades to messages, reflections, bookmarks and step
+-- states.
+--
+-- It is also unnecessary: a read-only count of that predicate against the hosted
+-- project returned 0 rows out of 64 sessions, and the local stack has none
+-- either. There is nothing to clean up, so this migration does not delete data.
+-- If forced rows ever do appear, they need a targeted one-off with a human
+-- deciding which are real -- not a blanket DELETE inside a migration.
+
+-- ============================================
+-- 2. scripture_seed_test_data: a guard that fires
+-- ============================================
+-- Body is unchanged from the live definition apart from the guard noted inline.
+CREATE OR REPLACE FUNCTION public.scripture_seed_test_data(p_session_count integer DEFAULT 1, p_include_reflections boolean DEFAULT false, p_include_messages boolean DEFAULT false, p_preset text DEFAULT NULL::text, p_bookmark_steps integer[] DEFAULT NULL::integer[], p_user1_id uuid DEFAULT NULL::uuid, p_user2_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+declare
+  v_caller_role text;
+  v_result jsonb;
+  v_session_ids uuid[] := '{}';
+  v_reflection_ids uuid[] := '{}';
+  v_message_ids uuid[] := '{}';
+  v_test_user1_id uuid;
+  v_test_user2_id uuid;
+  v_session_id uuid;
+  v_temp_id uuid;  -- separate variable for returning in sub-inserts
+  v_step_index int;
+  v_current_step int;
+  v_current_phase public.scripture_session_phase;
+  v_status public.scripture_session_status;
+  v_completed_at timestamptz;
+  i int;
+  j int;
+begin
+  -- Caller guard, replacing an `app.environment = 'production'` check that never
+  -- fired because that GUC is set in no environment, production included.
+  --
+  -- `current_user` is useless here: this function is SECURITY DEFINER owned by
+  -- postgres, so inside the body current_user is 'postgres' no matter who called.
+  -- The `role` GUC is not rewritten by SECURITY DEFINER, so it still reports the
+  -- role PostgREST switched to for the request, which is what we need. Measured
+  -- inside a definer body: authenticated -> 'authenticated', service_role ->
+  -- 'service_role', direct psql / migration / pgTAP -> the GUC default, 'none'.
+  --
+  -- Fail closed: an allow-list, so a role nobody anticipated is denied rather
+  -- than admitted. This is defence in depth behind the EXECUTE grant, which is
+  -- service_role-only as of 20260818000000; it exists so that a future
+  -- DROP FUNCTION + CREATE FUNCTION -- which resets the ACL and re-grants
+  -- PUBLIC -- does not silently reopen arbitrary cross-account seeding.
+  --
+  -- 'none' is the `role` GUC's default value, not an absence -- current_setting
+  -- returns the literal string, never NULL. It therefore means "no SET ROLE was
+  -- issued", which covers psql, migrations and pgTAP but ALSO covers
+  -- `authenticator`, the untrusted login role PostgREST itself connects as. So
+  -- 'none' is only trusted when session_user is genuinely an admin login;
+  -- service_role is trusted on the role GUC alone, because for a legitimate
+  -- service-key request session_user is 'authenticator' too.
+  v_caller_role := current_setting('role', true);
+  if not (
+       v_caller_role in ('postgres', 'service_role')
+       or (v_caller_role = 'none' and session_user in ('postgres', 'supabase_admin'))
+     ) then
+    raise exception 'scripture_seed_test_data is not callable by role %', v_caller_role
+      using errcode = '42501';
+  end if;
+
+  -- resolve the users to seed for
+  if p_user1_id is not null then
+    -- caller-scoped path: the caller owns these rows, so parallel callers do
+    -- not contend. validated rather than trusted, because a silently-wrong
+    -- user id produces sessions attached to somebody else's account and the
+    -- resulting test failure points nowhere near the cause.
+    v_test_user1_id := p_user1_id;
+    v_test_user2_id := p_user2_id;
+
+    if not exists (select 1 from auth.users where id = v_test_user1_id) then
+      raise exception 'p_user1_id % not found in auth.users', v_test_user1_id;
+    end if;
+
+    if v_test_user2_id is not null then
+      if v_test_user2_id = v_test_user1_id then
+        raise exception 'p_user1_id and p_user2_id must differ (both %)', v_test_user1_id;
+      end if;
+      if not exists (select 1 from auth.users where id = v_test_user2_id) then
+        raise exception 'p_user2_id % not found in auth.users', v_test_user2_id;
+      end if;
+    end if;
+  else
+    -- legacy fallback: first two users by creation order. retained so callers
+    -- that have not been updated keep working; not safe under parallelism.
+    select id into v_test_user1_id
+      from auth.users order by created_at, id limit 1;
+    select id into v_test_user2_id
+      from auth.users where id <> v_test_user1_id order by created_at, id limit 1;
+
+    -- if no users exist, we cannot seed (requires authenticated users)
+    if v_test_user1_id is null then
+      raise exception 'No users found in auth.users. Create test users first.';
+    end if;
+  end if;
+
+  -- determine session state based on preset
+  case p_preset
+    when 'mid_session' then
+      v_current_step := 7;
+      v_current_phase := 'reading';
+      v_status := 'in_progress';
+      v_completed_at := null;
+    when 'completed' then
+      v_current_step := 16;
+      v_current_phase := 'complete';
+      v_status := 'complete';
+      v_completed_at := now();
+    when 'with_help_flags' then
+      v_current_step := 7;
+      v_current_phase := 'reading';
+      v_status := 'in_progress';
+      v_completed_at := null;
+    when 'unlinked' then
+      v_current_step := 7;
+      v_current_phase := 'reading';
+      v_status := 'in_progress';
+      v_completed_at := null;
+    when 'at_reflection' then
+      v_current_step := 16;
+      v_current_phase := 'reflection';
+      v_status := 'in_progress';
+      v_completed_at := null;
+    else
+      -- default: fresh session
+      v_current_step := 0;
+      v_current_phase := 'lobby';
+      v_status := 'pending';
+      v_completed_at := null;
+  end case;
+
+  -- create sessions
+  for i in 1..p_session_count loop
+    insert into public.scripture_sessions (
+      mode,
+      user1_id,
+      user2_id,
+      current_phase,
+      current_step_index,
+      status,
+      version,
+      snapshot_json,
+      started_at,
+      completed_at
+    ) values (
+      case when p_preset in ('unlinked', 'at_reflection') then 'solo'::public.scripture_session_mode
+           when v_test_user2_id is not null then 'together'::public.scripture_session_mode
+           else 'solo'::public.scripture_session_mode end,
+      v_test_user1_id,
+      case when p_preset in ('unlinked', 'at_reflection') then null else v_test_user2_id end,
+      v_current_phase,
+      v_current_step,
+      v_status,
+      1,
+      jsonb_build_object('seeded', true, 'preset', coalesce(p_preset, 'default')),
+      now() - (i || ' hours')::interval,  -- stagger start times
+      v_completed_at
+    ) returning id into v_session_id;
+
+    v_session_ids := array_append(v_session_ids, v_session_id);
+
+    -- create step states for completed steps
+    for j in 0..v_current_step loop
+      insert into public.scripture_step_states (
+        session_id,
+        step_index,
+        user1_locked_at,
+        user2_locked_at,
+        advanced_at
+      ) values (
+        v_session_id,
+        j,
+        now() - ((v_current_step - j) || ' minutes')::interval,
+        case when p_preset in ('unlinked', 'at_reflection') then null
+             when v_test_user2_id is not null then now() - ((v_current_step - j) || ' minutes')::interval
+             else null end,
+        case when j = 16 and p_preset = 'at_reflection' then null
+             else now() - ((v_current_step - j) || ' minutes')::interval end
+      );
+    end loop;
+
+    -- create bookmarks for at_reflection preset when p_bookmark_steps is provided
+    if p_preset = 'at_reflection' and p_bookmark_steps is not null then
+      declare
+        v_bm_step int;
+      begin
+        foreach v_bm_step in array p_bookmark_steps loop
+          insert into public.scripture_bookmarks (
+            session_id,
+            step_index,
+            user_id,
+            share_with_partner
+          ) values (
+            v_session_id,
+            v_bm_step,
+            v_test_user1_id,
+            false
+          );
+        end loop;
+      end;
+    end if;
+
+    -- create reflections if requested (uses v_temp_id to avoid overwriting v_session_id)
+    if p_include_reflections then
+      for j in 0..least(v_current_step, 16) loop
+        insert into public.scripture_reflections (
+          session_id,
+          step_index,
+          user_id,
+          rating,
+          notes,
+          is_shared,
+          created_at
+        ) values (
+          v_session_id,
+          j,
+          v_test_user1_id,
+          (j % 5) + 1,  -- rotating rating 1-5
+          'Test reflection for step ' || j,
+          j % 2 = 0,  -- share every other one
+          now() - ((v_current_step - j) || ' minutes')::interval
+        ) returning id into v_temp_id;
+        v_reflection_ids := array_append(v_reflection_ids, v_temp_id);
+      end loop;
+    end if;
+
+    -- create messages if requested (uses v_temp_id to avoid overwriting v_session_id)
+    if p_include_messages then
+      for j in 1..3 loop
+        insert into public.scripture_messages (
+          session_id,
+          sender_id,
+          message,
+          created_at
+        ) values (
+          v_session_id,
+          v_test_user1_id,
+          'Test prayer message ' || j,
+          now() - (j || ' minutes')::interval
+        ) returning id into v_temp_id;
+        v_message_ids := array_append(v_message_ids, v_temp_id);
+      end loop;
+    end if;
+  end loop;
+
+  -- build result
+  v_result := jsonb_build_object(
+    'session_ids', to_jsonb(v_session_ids),
+    'session_count', p_session_count,
+    'preset', coalesce(p_preset, 'default'),
+    'test_user1_id', v_test_user1_id,
+    'test_user2_id', v_test_user2_id
+  );
+
+  if p_include_reflections then
+    v_result := v_result || jsonb_build_object('reflection_ids', to_jsonb(v_reflection_ids));
+  end if;
+
+  if p_include_messages then
+    v_result := v_result || jsonb_build_object('message_ids', to_jsonb(v_message_ids));
+  end if;
+
+  return v_result;
+end;
+$function$;
+
+commit;

--- a/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
+++ b/supabase/migrations/20260818000001_partner_scoped_together_sessions_and_seeder_guard.sql
@@ -114,6 +114,14 @@ begin
     -- forced before this migration would still be handed back by the reuse
     -- branch, reopening the same channel.
     --
+    -- Accepted consequence of that ordering: a couple who unlinks can no longer
+    -- REJOIN an in-progress together lobby through this RPC, only read the row
+    -- they are already a member of. That is the right trade against re-serving a
+    -- forced session, and nothing reachable regresses -- the Together button is
+    -- disabled unless partnerStatus is 'linked'
+    -- (src/components/scripture-reading/containers/ScriptureOverview.tsx:509) --
+    -- and scripture_convert_to_solo remains available to the stranded caller.
+    --
     -- public. qualification is required: this function is SET search_path TO ''.
     if p_partner_id is distinct from public.get_my_partner_id() then
       raise exception 'Together mode requires your linked partner.'
@@ -397,7 +405,15 @@ begin
   -- 'none' is only trusted when session_user is genuinely an admin login;
   -- service_role is trusted on the role GUC alone, because for a legitimate
   -- service-key request session_user is 'authenticator' too.
-  v_caller_role := current_setting('role', true);
+  --
+  -- The coalesce is deliberate belt-and-braces, not dead code. current_setting's
+  -- missing_ok signature is NULL-able, and `if not (NULL in (...) or ...)` is
+  -- NULL, which plpgsql treats as false -- the RAISE would be skipped and the
+  -- call would proceed. That is the exact fall-through that made
+  -- accept_partner_request exploitable, and a guard whose comment says "fail
+  -- closed" should not carry it, unreachable or not. '' is in no allow-list, so
+  -- a NULL denies.
+  v_caller_role := coalesce(current_setting('role', true), '');
   if not (
        v_caller_role in ('postgres', 'service_role')
        or (v_caller_role = 'none' and session_user in ('postgres', 'supabase_admin'))

--- a/supabase/tests/database/03_scripture_rpcs.sql
+++ b/supabase/tests/database/03_scripture_rpcs.sql
@@ -40,6 +40,13 @@ declare
 begin
   v_user_a := tests.create_test_user('rpc_user_a@test.com');
   v_user_b := tests.create_test_user('rpc_user_b@test.com');
+
+  -- scripture_create_session now requires p_partner_id to be the caller's real
+  -- partner, so the together-mode test below needs a genuine link. Same pattern
+  -- as 10_scripture_lobby.sql:92-93.
+  update public.users set partner_id = v_user_b where id = v_user_a;
+  update public.users set partner_id = v_user_a where id = v_user_b;
+
   perform set_config('tests.user_a', v_user_a::text, true);
   perform set_config('tests.user_b', v_user_b::text, true);
 end;

--- a/supabase/tests/database/13_scripture_create_session_together_semantics.sql
+++ b/supabase/tests/database/13_scripture_create_session_together_semantics.sql
@@ -56,6 +56,12 @@ begin
   v_user1 := tests.create_test_user('create_session_pair_user1@test.com');
   v_user2 := tests.create_test_user('create_session_pair_user2@test.com');
 
+  -- scripture_create_session now requires p_partner_id to be the caller's real
+  -- partner. Both directions are needed: 4.3-DB-006 calls the RPC as user2 with
+  -- user1 as the partner. Same pattern as 10_scripture_lobby.sql:92-93.
+  update public.users set partner_id = v_user2 where id = v_user1;
+  update public.users set partner_id = v_user1 where id = v_user2;
+
   perform set_config('test.user1_id', v_user1::text, true);
   perform set_config('test.user2_id', v_user2::text, true);
 end; $$;

--- a/supabase/tests/database/18_function_execute_grants.sql
+++ b/supabase/tests/database/18_function_execute_grants.sql
@@ -1,0 +1,295 @@
+-- ============================================
+-- pgTAP: anon must not reach SECURITY DEFINER functions, and the partner
+-- request guards must deny a NULL auth.uid()
+--
+-- Regression cover for 20260818000000. Both halves matter independently:
+--
+--   * The grant half is what the Supabase advisor lints 0028/0029 measure. It
+--     regresses silently -- DROP FUNCTION + CREATE FUNCTION re-derives the ACL
+--     and hands anon EXECUTE back, and nothing else in the suite would fail.
+--     20260818000000 cannot prevent that (see its header: the schema-scoped
+--     ALTER DEFAULT PRIVILEGES form is a no-op and the global form breaks these
+--     very test helpers), so FN-GRANT-002 below IS the regression net. It
+--     enumerates rather than naming functions, so a function added later is
+--     covered without editing this file.
+--   * The guard half is the actual vulnerability. `IF auth.uid() != v_to_user_id`
+--     does not fire when auth.uid() is NULL, because NULL != x is NULL and
+--     plpgsql treats a NULL condition as false. With that shape restored, an
+--     unauthenticated caller could accept a partner request on the victim's
+--     behalf and inherit read access to their moods, photos and storage objects.
+--     These tests call the functions with the role left at postgres and only the
+--     JWT claims cleared, so the guard is exercised even if the grant is loose.
+-- ============================================
+
+begin;
+
+create schema if not exists tests;
+grant usage on schema tests to authenticated, anon;
+
+select plan(21);
+
+create or replace function tests.create_test_user(test_email text default 'test@example.com')
+returns uuid language plpgsql security definer set search_path = '' as $$
+declare user_id uuid;
+begin
+  user_id := gen_random_uuid();
+  insert into auth.users (id, instance_id, email, encrypted_password, aud, role, email_confirmed_at, created_at, updated_at, confirmation_token)
+  values (user_id, '00000000-0000-0000-0000-000000000000', test_email, extensions.crypt('password123', extensions.gen_salt('bf')), 'authenticated', 'authenticated', now(), now(), now(), '');
+  return user_id;
+end; $$;
+
+create or replace function tests.authenticate_as(test_user_id uuid)
+returns void language plpgsql set search_path = '' as $$
+begin
+  perform set_config('role', 'authenticated', true);
+  perform set_config('request.jwt.claims', json_build_object('sub', test_user_id::text, 'role', 'authenticated', 'aud', 'authenticated')::text, true);
+end; $$;
+
+-- Clears the JWT only, leaving the database role alone, so auth.uid() is NULL
+-- while the caller still holds EXECUTE. That isolates the in-function guard from
+-- the grant; tests.reset_role() in the other files would conflate the two.
+create or replace function tests.clear_jwt()
+returns void language plpgsql set search_path = '' as $$
+begin
+  perform set_config('request.jwt.claims', '', true);
+end; $$;
+
+-- ============================================
+-- Part 1: EXECUTE privileges (lints 0028 / 0029)
+-- ============================================
+
+-- anon must not hold EXECUTE on any SECURITY DEFINER function in public.
+select is(
+  (
+    select coalesce(string_agg(p.oid::regprocedure::text, ', ' order by p.proname), '')
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prosecdef
+      and p.prokind in ('f', 'p')
+      and not exists (select 1 from pg_depend d where d.objid = p.oid and d.deptype = 'e')
+      and has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  '',
+  'FN-GRANT-001: no SECURITY DEFINER function in public is executable by anon'
+);
+
+-- Same for every other function in public, SECURITY INVOKER included: they are
+-- all reachable at /rest/v1/rpc/<name> and none is a public endpoint.
+select is(
+  (
+    select coalesce(string_agg(p.oid::regprocedure::text, ', ' order by p.proname), '')
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prokind in ('f', 'p')
+      and not exists (select 1 from pg_depend d where d.objid = p.oid and d.deptype = 'e')
+      and has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  '',
+  'FN-GRANT-002: no function in public is executable by anon'
+);
+
+-- The test seeder writes rows for arbitrary user ids and validates only that
+-- they exist, so it must stay off the end-user API surface entirely (lint 0029).
+select ok(
+  not has_function_privilege('authenticated', 'public.scripture_seed_test_data(int, boolean, boolean, text, int[], uuid, uuid)', 'EXECUTE'),
+  'FN-GRANT-003: scripture_seed_test_data is not executable by authenticated'
+);
+
+select ok(
+  has_function_privilege('service_role', 'public.scripture_seed_test_data(int, boolean, boolean, text, int[], uuid, uuid)', 'EXECUTE'),
+  'FN-GRANT-004: scripture_seed_test_data is still executable by service_role'
+);
+
+-- The set of functions `authenticated` may call, pinned exactly. A per-function
+-- ok() cannot catch a function that GAINS a grant it should not have, and that
+-- is the failure mode that actually happened: applying only the anon/PUBLIC
+-- revokes left scripture_seed_test_data callable by authenticated on the hosted
+-- project, because hosted's default ACL grants authenticated explicitly while
+-- local's does not. This assertion goes red on a missing or an extra grant.
+--
+-- The list is the LOCAL set. The hosted project also has get_random_daily_message,
+-- which no migration in this repo creates -- it is drift, nothing calls it, and it
+-- is left executable by authenticated because that is its pre-existing behaviour.
+-- This file only ever runs against a stack built from these migrations, so the
+-- extra function cannot appear here; if it ever does, that means the drift got
+-- committed and this list should grow with it.
+select is(
+  (
+    select coalesce(string_agg(p.proname, ', ' order by p.proname), '')
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prokind in ('f', 'p')
+      and not exists (select 1 from pg_depend d where d.objid = p.oid and d.deptype = 'e')
+      and has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'accept_partner_request, decline_partner_request, get_my_partner_id, '
+  || 'is_scripture_session_member, scripture_convert_to_solo, scripture_create_session, '
+  || 'scripture_end_session, scripture_get_couple_stats, scripture_lock_in, '
+  || 'scripture_select_role, scripture_submit_reflection, scripture_toggle_ready, '
+  || 'scripture_undo_lock_in',
+  'FN-GRANT-008: authenticated holds EXECUTE on exactly the app RPCs'
+);
+
+select ok(
+  not has_function_privilege('authenticated', 'public.sync_user_profile()', 'EXECUTE'),
+  'FN-GRANT-009: sync_user_profile is not executable by authenticated'
+);
+
+-- Revoking PUBLIC strips the implicit grant these rode on, so the explicit
+-- authenticated grants are load-bearing. Without them the partner buttons and
+-- every scripture read return 42501.
+select ok(
+  has_function_privilege('authenticated', 'public.accept_partner_request(uuid)', 'EXECUTE'),
+  'FN-GRANT-005: accept_partner_request is executable by authenticated'
+);
+
+select ok(
+  has_function_privilege('authenticated', 'public.decline_partner_request(uuid)', 'EXECUTE'),
+  'FN-GRANT-006: decline_partner_request is executable by authenticated'
+);
+
+-- Called from nine RLS policies that are declared TO public, so it executes as
+-- the invoking role. Losing this grant breaks every authenticated read of
+-- scripture_step_states, scripture_reflections, scripture_bookmarks and
+-- scripture_messages.
+select ok(
+  has_function_privilege('authenticated', 'public.is_scripture_session_member(uuid)', 'EXECUTE'),
+  'FN-GRANT-007: is_scripture_session_member is executable by authenticated'
+);
+
+-- ============================================
+-- Part 2: the guards themselves
+-- ============================================
+
+create temporary table t_ids as
+select
+  tests.create_test_user('fn-grants-sender@example.com') as sender_id,
+  tests.create_test_user('fn-grants-sender2@example.com') as sender2_id,
+  tests.create_test_user('fn-grants-recipient@example.com') as recipient_id,
+  tests.create_test_user('fn-grants-outsider@example.com') as outsider_id;
+
+-- The later assertions read t_ids after tests.authenticate_as has switched the
+-- role away from postgres, so the temp table needs its own grant.
+grant select on t_ids to authenticated, anon;
+
+insert into public.users (id, email, display_name)
+select sender_id, 'fn-grants-sender@example.com', 'Sender' from t_ids
+on conflict (id) do nothing;
+insert into public.users (id, email, display_name)
+select sender2_id, 'fn-grants-sender2@example.com', 'Sender Two' from t_ids
+on conflict (id) do nothing;
+insert into public.users (id, email, display_name)
+select recipient_id, 'fn-grants-recipient@example.com', 'Recipient' from t_ids
+on conflict (id) do nothing;
+insert into public.users (id, email, display_name)
+select outsider_id, 'fn-grants-outsider@example.com', 'Outsider' from t_ids
+on conflict (id) do nothing;
+
+-- Two senders, because idx_partner_requests_unique forbids a second pending
+-- request between the same pair.
+insert into public.partner_requests (id, from_user_id, to_user_id, status)
+select '77777777-0000-0000-0000-000000000001', sender_id, recipient_id, 'pending' from t_ids;
+insert into public.partner_requests (id, from_user_id, to_user_id, status)
+select '77777777-0000-0000-0000-000000000002', sender2_id, recipient_id, 'pending' from t_ids;
+
+-- accept: a NULL auth.uid() must be denied, not fall through the != guard.
+select tests.clear_jwt();
+select throws_ok(
+  $$select public.accept_partner_request('77777777-0000-0000-0000-000000000001')$$,
+  'Authentication required',
+  'FN-GUARD-001: accept_partner_request rejects a NULL auth.uid()'
+);
+
+-- and the link must not have been created.
+select is(
+  (select partner_id from public.users where id = (select recipient_id from t_ids)),
+  null,
+  'FN-GUARD-002: no partner link was created by the unauthenticated accept'
+);
+
+select is(
+  (select status from public.partner_requests where id = '77777777-0000-0000-0000-000000000001'),
+  'pending',
+  'FN-GUARD-003: the request is still pending after the unauthenticated accept'
+);
+
+-- decline: same.
+select throws_ok(
+  $$select public.decline_partner_request('77777777-0000-0000-0000-000000000002')$$,
+  'Authentication required',
+  'FN-GUARD-004: decline_partner_request rejects a NULL auth.uid()'
+);
+
+select is(
+  (select status from public.partner_requests where id = '77777777-0000-0000-0000-000000000002'),
+  'pending',
+  'FN-GUARD-005: the request is still pending after the unauthenticated decline'
+);
+
+-- A signed-in non-recipient must still be rejected -- the guard has to deny the
+-- wrong user as well as the missing one.
+select tests.authenticate_as((select outsider_id from t_ids));
+select throws_ok(
+  $$select public.accept_partner_request('77777777-0000-0000-0000-000000000001')$$,
+  'Only the recipient can accept a partner request',
+  'FN-GUARD-006: accept_partner_request rejects a signed-in non-recipient'
+);
+
+-- ============================================
+-- Part 3: the signed-in path to the same forged link
+-- ============================================
+-- Repairing the NULL guard only stops an anonymous caller. The recipient of a
+-- request used to be able to rewrite its from_user_id to an arbitrary victim and
+-- then accept it legitimately, because the UPDATE policy had no WITH CHECK and
+-- Postgres reuses USING, which constrains to_user_id only. 20260818000000 drops
+-- that policy and revokes UPDATE; these pin both halves.
+
+select ok(
+  not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'partner_requests' and cmd = 'UPDATE'
+  ),
+  'FN-REQ-001: partner_requests has no UPDATE policy'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.partner_requests', 'UPDATE'),
+  'FN-REQ-002: authenticated cannot UPDATE partner_requests'
+);
+
+select ok(
+  not has_table_privilege('anon', 'public.partner_requests', 'UPDATE'),
+  'FN-REQ-003: anon cannot UPDATE partner_requests'
+);
+
+-- The attack itself: the recipient tries to repoint the request at a stranger.
+select tests.authenticate_as((select recipient_id from t_ids));
+select throws_ok(
+  $$update public.partner_requests
+      set from_user_id = (select outsider_id from t_ids)
+    where id = '77777777-0000-0000-0000-000000000001'$$,
+  '42501',
+  'permission denied for table partner_requests',
+  'FN-REQ-004: the recipient cannot rewrite from_user_id to a third party'
+);
+
+-- The real recipient still works, so the fix did not just deny everything.
+select tests.authenticate_as((select recipient_id from t_ids));
+select lives_ok(
+  $$select public.accept_partner_request('77777777-0000-0000-0000-000000000001')$$,
+  'FN-GUARD-007: accept_partner_request still succeeds for the recipient'
+);
+
+-- ...and it wrote through the SECURITY DEFINER path despite the table-level
+-- revoke, which is the property that makes dropping the write path safe.
+select is(
+  (select partner_id from public.users where id = (select recipient_id from t_ids)),
+  (select sender_id from t_ids),
+  'FN-GUARD-008: the accepted link points at the original sender'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/19_together_session_partner_scope.sql
+++ b/supabase/tests/database/19_together_session_partner_scope.sql
@@ -1,0 +1,266 @@
+-- ============================================
+-- pgTAP: a `together` session can only name the caller's real partner, and the
+-- test seeder refuses an end-user role even if its EXECUTE grant comes back
+--
+-- Regression cover for 20260818000001. Three separate things are pinned here,
+-- because each failed independently before that migration:
+--
+--   * scripture_create_session accepted ANY auth.users id as p_partner_id, so a
+--     stranger could open a together session with a victim. Both rows then pass
+--     is_scripture_session_member, which is what scripture_messages_select keys
+--     on -- a two-way message channel the victim never agreed to.
+--   * Guarding only the RPC was not enough. `authenticated` holds a direct
+--     INSERT grant on scripture_sessions and the insert policy checked only
+--     user1_id, so a client could skip the RPC and insert the same row by hand.
+--   * scripture_seed_test_data's in-body guard read a GUC that is set nowhere,
+--     so it never fired. The grant is what protects it today; this proves the
+--     body now refuses on its own, which is what makes a future ACL regression
+--     survivable.
+-- ============================================
+
+begin;
+
+create schema if not exists tests;
+grant usage on schema tests to authenticated, anon;
+
+select plan(15);
+
+create or replace function tests.create_test_user(test_email text default 'test@example.com')
+returns uuid language plpgsql security definer set search_path = '' as $$
+declare user_id uuid;
+begin
+  user_id := gen_random_uuid();
+  insert into auth.users (id, instance_id, email, encrypted_password, aud, role, email_confirmed_at, created_at, updated_at, confirmation_token)
+  values (user_id, '00000000-0000-0000-0000-000000000000', test_email, extensions.crypt('password123', extensions.gen_salt('bf')), 'authenticated', 'authenticated', now(), now(), now(), '');
+  return user_id;
+end; $$;
+
+create or replace function tests.authenticate_as(test_user_id uuid)
+returns void language plpgsql set search_path = '' as $$
+begin
+  perform set_config('role', 'authenticated', true);
+  perform set_config('request.jwt.claims', json_build_object('sub', test_user_id::text, 'role', 'authenticated', 'aud', 'authenticated')::text, true);
+end; $$;
+
+-- A linked couple (A <-> B) and an unrelated third party (C).
+create temporary table t as
+select
+  tests.create_test_user('together_scope_a@test.com') as a,
+  tests.create_test_user('together_scope_b@test.com') as b,
+  tests.create_test_user('together_scope_c@test.com') as c;
+
+grant select on t to authenticated, anon;
+
+update public.users set partner_id = (select b from t) where id = (select a from t);
+update public.users set partner_id = (select a from t) where id = (select b from t);
+
+-- ============================================
+-- Part 1: the RPC
+-- ============================================
+
+select tests.authenticate_as((select a from t));
+
+-- The legitimate case still works, so the guard is not just denying everything.
+select lives_ok(
+  $$select public.scripture_create_session('together', (select b from t))$$,
+  'TS-001: a user can start a together session with their linked partner'
+);
+
+select tests.authenticate_as((select a from t));
+select throws_ok(
+  $$select public.scripture_create_session('together', (select c from t))$$,
+  '42501',
+  'Together mode requires your linked partner.',
+  'TS-002: a user cannot start a together session with a stranger'
+);
+
+-- An unpartnered caller reads NULL from get_my_partner_id and must be denied,
+-- not fall through a NULL comparison.
+select tests.authenticate_as((select c from t));
+select throws_ok(
+  $$select public.scripture_create_session('together', (select a from t))$$,
+  '42501',
+  'Together mode requires your linked partner.',
+  'TS-003: an unpartnered user cannot start a together session at all'
+);
+
+-- Solo is unaffected -- it never reads partner_id.
+select tests.authenticate_as((select c from t));
+select lives_ok(
+  $$select public.scripture_create_session('solo')$$,
+  'TS-004: solo sessions still work for an unpartnered user'
+);
+
+-- ============================================
+-- Part 2: the direct-INSERT path around the RPC
+-- ============================================
+
+select tests.authenticate_as((select c from t));
+select throws_ok(
+  format(
+    $$insert into public.scripture_sessions
+        (mode, user1_id, user2_id, current_phase, current_step_index, status, version, started_at)
+      values ('together', %L, %L, 'lobby', 0, 'in_progress', 1, now())$$,
+    (select c from t), (select a from t)
+  ),
+  '42501',
+  'new row violates row-level security policy for table "scripture_sessions"',
+  'TS-005: a stranger cannot hand-insert a together session naming a victim'
+);
+
+select tests.authenticate_as((select a from t));
+select lives_ok(
+  format(
+    $$insert into public.scripture_sessions
+        (mode, user1_id, user2_id, current_phase, current_step_index, status, version, started_at)
+      values ('together', %L, %L, 'lobby', 0, 'in_progress', 1, now())$$,
+    (select a from t), (select b from t)
+  ),
+  'TS-006: a real couple can still insert a together session directly'
+);
+
+-- ============================================
+-- Part 2b: the UPDATE path around both the RPC and the insert policy
+-- ============================================
+-- Create a solo session (needs no partner), then try to repoint it at a victim.
+-- The insert policy cannot stop this and the update policy has no WITH CHECK,
+-- so the BEFORE UPDATE trigger is what has to hold.
+select tests.authenticate_as((select c from t));
+select lives_ok(
+  $$select public.scripture_create_session('solo')$$,
+  'TS-009: an unpartnered user can still create a solo session'
+);
+
+select tests.authenticate_as((select c from t));
+select throws_ok(
+  format(
+    $$update public.scripture_sessions
+         set mode = 'together', user2_id = %L
+       where user1_id = %L and mode = 'solo'$$,
+    (select a from t), (select c from t)
+  ),
+  '42501',
+  'scripture_sessions.user2_id cannot be reassigned',
+  'TS-010: a solo session cannot be repointed at a stranger as user2_id'
+);
+
+-- user1_id must not move either -- that would hand the row to someone else.
+select tests.authenticate_as((select c from t));
+select throws_ok(
+  format(
+    $$update public.scripture_sessions set user1_id = %L where user1_id = %L$$,
+    (select a from t), (select c from t)
+  ),
+  '42501',
+  'scripture_sessions.user1_id is immutable',
+  'TS-011: user1_id cannot be reassigned'
+);
+
+-- scripture_convert_to_solo legitimately clears user2_id, so NULL must pass.
+select tests.authenticate_as((select a from t));
+select lives_ok(
+  format(
+    $$update public.scripture_sessions
+         set mode = 'solo', user2_id = null
+       where user1_id = %L and user2_id = %L$$,
+    (select a from t), (select b from t)
+  ),
+  'TS-012: clearing user2_id still works (scripture_convert_to_solo path)'
+);
+
+-- ============================================
+-- Part 2c: repointing a child row into someone else's session
+-- ============================================
+-- The reflections/bookmarks INSERT policies check session membership; their
+-- UPDATE policies did not, so an attacker could write a row in their own session
+-- and then move it into a victim's. Only the UPDATE side is pinned here -- the
+-- INSERT side is already covered by 02_rls_policies.sql.
+select set_config('role', 'none', true);
+
+insert into public.scripture_sessions (id, mode, user1_id, current_phase, current_step_index, status, version, started_at)
+select '99999999-0000-0000-0000-000000000001', 'solo', c, 'reading', 0, 'in_progress', 1, now() from t;
+insert into public.scripture_sessions (id, mode, user1_id, current_phase, current_step_index, status, version, started_at)
+select '99999999-0000-0000-0000-000000000002', 'solo', a, 'reading', 0, 'in_progress', 1, now() from t;
+
+insert into public.scripture_reflections (session_id, step_index, user_id, rating, notes, is_shared)
+select '99999999-0000-0000-0000-000000000002', 0, a, 5, 'attacker text', true from t;
+insert into public.scripture_bookmarks (session_id, step_index, user_id, share_with_partner)
+select '99999999-0000-0000-0000-000000000002', 0, a, true from t;
+
+select tests.authenticate_as((select a from t));
+select throws_ok(
+  $$update public.scripture_reflections
+       set session_id = '99999999-0000-0000-0000-000000000001'
+     where notes = 'attacker text'$$,
+  '42501',
+  'new row violates row-level security policy for table "scripture_reflections"',
+  'TS-013: a reflection cannot be repointed into a session the author is not in'
+);
+
+select tests.authenticate_as((select a from t));
+select throws_ok(
+  $$update public.scripture_bookmarks
+       set session_id = '99999999-0000-0000-0000-000000000001'
+     where session_id = '99999999-0000-0000-0000-000000000002'$$,
+  '42501',
+  'new row violates row-level security policy for table "scripture_bookmarks"',
+  'TS-014: a bookmark cannot be repointed into a session the author is not in'
+);
+
+-- The ordinary edit-my-own-reflection path must still work.
+select tests.authenticate_as((select a from t));
+select lives_ok(
+  $$update public.scripture_reflections
+       set notes = 'edited in place', rating = 4
+     where notes = 'attacker text'$$,
+  'TS-015: a user can still edit their own reflection inside their own session'
+);
+
+-- ============================================
+-- Part 3: the seeder guard, independent of its grant
+-- ============================================
+-- FN-GRANT-003 in 18_function_execute_grants.sql proves the grant is right
+-- today. This proves the body refuses on its own, so restoring the grant is not
+-- immediately exploitable -- exactly what the old app.environment check failed
+-- to do.
+savepoint seeder_probe;
+
+-- Back to the owning role first: the assertions above left the session as
+-- `authenticated`, and a GRANT issued by a non-owner is a no-op with only a
+-- warning, which would make this test pass for the wrong reason (the caller
+-- would be blocked by the missing grant, not by the guard being tested).
+select set_config('role', 'none', true);
+
+grant execute on function public.scripture_seed_test_data(int, boolean, boolean, text, int[], uuid, uuid)
+  to authenticated;
+
+select tests.authenticate_as((select c from t));
+select throws_ok(
+  format(
+    $$select public.scripture_seed_test_data(1, false, false, null, null, %L, %L)$$,
+    (select a from t), (select b from t)
+  ),
+  '42501',
+  'scripture_seed_test_data is not callable by role authenticated',
+  'TS-007: the seeder refuses an authenticated caller even with EXECUTE granted'
+);
+
+rollback to seeder_probe;
+
+-- ...and still works for a trusted caller. 'none' is the role GUC's DEFAULT
+-- value, not an absence, so this restores the psql / migration / pgTAP position.
+-- The guard trusts 'none' only when session_user is an admin login, which it is
+-- here (postgres); a PostgREST request reaching 'none' has session_user
+-- 'authenticator' and is refused.
+select set_config('role', 'none', true);
+select set_config('request.jwt.claims', '', true);
+select lives_ok(
+  format(
+    $$select public.scripture_seed_test_data(1, false, false, null, null, %L, %L)$$,
+    (select a from t), (select b from t)
+  ),
+  'TS-008: the seeder still runs for a trusted caller'
+);
+
+select * from finish();
+rollback;

--- a/tests/support/helpers/scripture-overview.ts
+++ b/tests/support/helpers/scripture-overview.ts
@@ -53,8 +53,24 @@ async function getBrowserUserId(page: Page): Promise<string> {
 
 /**
  * Re-assign an API-seeded session to the browser's logged-in user.
- * The seeding RPC uses `auth.users ORDER BY created_at LIMIT 1` which may
- * not match the worker-specific user the browser is authenticated as.
+ *
+ * This is now a no-op in practice, and deliberately left in place rather than
+ * deleted. The docstring used to say the seeding RPC resolves its user with
+ * `auth.users ORDER BY created_at LIMIT 1`, which is no longer true:
+ * `createTestSession` (../factories) defaults `p_user1_id` to the calling
+ * worker's own pair, which is the same account the browser is signed in as, so
+ * `browserUserId` already equals `user1_id`.
+ *
+ * It matters because `scripture_sessions` now carries a BEFORE UPDATE trigger
+ * (`scripture_sessions_freeze_membership`, migration 20260818000001) that makes
+ * `user1_id` immutable and forbids repointing `user2_id`. The trigger compares
+ * with `is distinct from`, so writing the same id back is allowed — but the
+ * moment these two ids diverge this call fails with 42501 rather than silently
+ * reassigning the session to another account. Triggers are not skipped for
+ * BYPASSRLS roles, so using `supabaseAdmin` here does not exempt it.
+ *
+ * If a future change makes the seeded user and the browser user genuinely
+ * different, do not disable the trigger — fix the seeding so they match.
  */
 export async function adoptSessionForBrowserUser(params: {
   supabaseAdmin: TypedSupabaseClient;


### PR DESCRIPTION
Closes the ten `anon_security_definer_function_executable` (0028) advisor warnings, plus four authorization holes found while verifying them.

> [!IMPORTANT]
> **Both migrations are already applied to production** (`xojempkrugifnaveqtqc`), at the owner's direction, because two of these were live and unauthenticated. This PR is the reviewable record of what was applied, not a pending change. Advisor re-run after deploy shows zero 0028 warnings and no new ones.

**Base is `feature/love-note-delete-for-me` (#264), not `main`** — see the numbering note at the bottom.

## What was actually broken

Each of these was reproduced end to end against a local stack before being fixed, and re-run afterwards to confirm it was dead.

| | Severity | Reachable by |
|---|---|---|
| `accept_partner_request` / `decline_partner_request` NULL-poisoned guard | critical | anyone, unauthenticated |
| `scripture_seed_test_data` on the public API | critical | anyone, unauthenticated |
| `partner_requests` UPDATE policy with no `WITH CHECK` | critical | any signed-in user |
| `scripture_sessions` INSERT + UPDATE policies | high | any signed-in user |
| `scripture_reflections` / `scripture_bookmarks` UPDATE policies | high | any signed-in user |

### 1. Unauthenticated partner-link forgery

Both partner RPCs guarded on `IF auth.uid() != v_to_user_id THEN RAISE`. For an anonymous caller `auth.uid()` is NULL, `NULL != x` is NULL, and plpgsql treats a NULL condition as **false** — so the exception never fired.

Full chain, demonstrated: attacker signs up, sends a partner request to a victim (allowed — the INSERT policy only requires `auth.uid() = from_user_id`), then replays the accept RPC **with the Authorization header removed**. The link is created without the victim ever seeing the request. Holding `partner_id` then grants read access to the victim's profile, every mood entry and note, every photo row, and the underlying `storage.objects` in the `photos` and `love-notes-images` buckets.

It was also unrecoverable: `users_update_self_safe` forbids clearing your own `partner_id`, and there is no unlink RPC.

Guards now reject a NULL `auth.uid()` explicitly and compare with `IS DISTINCT FROM`.

### 2. The same link, one layer up

Fixing the guard only stopped *anonymous* callers. `Users can update received requests` had no `WITH CHECK`, and Postgres reuses `USING` when it is absent — which constrains only `to_user_id`. So a request's recipient could rewrite `from_user_id` to any victim and then accept it legitimately. Same irreversible link, one free signup instead of none.

`WITH CHECK` cannot express the rule (it cannot see `OLD`), and the app never UPDATEs that table — `partnerService.ts` inserts at `:184` and selects at `:222`; accept/decline go through the RPCs. So the write path is removed rather than fenced.

### 3. Test seeder on the public API

`scripture_seed_test_data` was callable by anon and by every signed-in user, takes arbitrary user ids, and validates only that they *exist*. Its sole guard read `app.environment` — a GUC set in no environment, production included, so the branch was dead everywhere. Passing `p_user1_id = victim, p_user2_id = self` mints a session the attacker is a member of.

Now `service_role` only, plus an in-body guard that fires independently of the grant — verified by re-granting EXECUTE to `authenticated` and confirming the **body** still refuses.

`current_user` would have been useless here: inside a SECURITY DEFINER function it reads as the owner (`postgres`) for attacker and admin alike. The guard reads the `role` GUC, which SECURITY DEFINER does not rewrite. `'none'` is that GUC's *default value*, not an absence, and it also covers `authenticator` — the login role PostgREST connects as — so `'none'` is trusted only when `session_user` is an admin login.

### 4. Forced `together` sessions, and three ways around the fix

`scripture_create_session` validated `p_partner_id` only as "is this a real account", never "is this **my** partner", so a stranger could open a session with any user id they knew. Both rows then satisfy `is_scripture_session_member`, which `scripture_messages_select` keys on — a two-way channel the victim never agreed to.

Guarding the RPC alone was cosmetic:

- **Direct INSERT** skipped the RPC entirely (policy constrained only `user1_id`).
- **UPDATE** was worse — create a solo session, which needs no partner, then repoint it at a victim. RLS cannot see `OLD`, and expressing it as a value constraint would strand a legitimate in-flight session the moment a couple unlinks. So this is a `BEFORE UPDATE` trigger: `user1_id` immutable, `user2_id` clearable but never reassignable — exactly what `scripture_convert_to_solo` needs and nothing more.
- **`scripture_reflections` / `scripture_bookmarks`**: their INSERT policies check session membership, their UPDATE policies did not. Reproduced attacker-authored text appearing inside a victim's private session.

## Deliberately not done

- **No data is deleted.** An earlier draft removed `together` sessions whose users are not mutually linked, but that predicate cannot distinguish a forced session from a couple who has since unlinked — membership is keyed on user ids only. A read-only count against production returned **0 candidates out of 64 sessions**, so there was nothing to clean and a real risk of destroying in-progress sessions.
- **Session membership after an unlink is left as-is** (confirmed intended): each person keeps access to old shared sessions.
- The 8 remaining `0029` warnings are the app's real RPCs and are correct by design. `get_random_daily_message` is production-only drift — no migration creates it and nothing calls it.

## Why the fix cannot silently regress

`DROP FUNCTION` + `CREATE FUNCTION` re-derives a function's ACL and hands `anon` EXECUTE back — and this repo already does that. The obvious prevention does not work: `ALTER DEFAULT PRIVILEGES ... IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS` is a **no-op** on PG17 (a schema-scoped default ACL merges add-only onto `acldefault()` and cannot subtract PUBLIC's built-in EXECUTE, measured). The global form works but strips PUBLIC EXECUTE in every schema and breaks the inline `tests.*` pgTAP helpers — 158 passing down to 108.

So `18_function_execute_grants.sql` is the net instead: it **enumerates** every function in `public` rather than naming them, so anything added later is covered without editing it. It already earned its keep — it caught the new trigger function in this very PR landing anon-executable.

Note `REVOKE ... FROM anon` alone is a no-op: the privilege is held by PUBLIC and an ACL check is a union with no deny entry. Revoking PUBLIC also strips the implicit grant `authenticated` relied on, hence the explicit grants.

## Local vs hosted — a trap worth knowing

The two databases grant function EXECUTE differently:

- local `pg_default_acl`: `{postgres=X/postgres}` — roles reach functions only via PostgreSQL's built-in PUBLIC default, so revoking PUBLIC removes `authenticated` as a side effect
- hosted: `{postgres=X,anon=X,authenticated=X,service_role=X}` — **separate explicit grants that survive revoking PUBLIC**

A locally-green revoke therefore proves nothing about production. This bit exactly once: after deploying, prod still reported `scripture_seed_test_data` executable by `authenticated`. Fixed with an explicit revoke that is a no-op locally, and `FN-GRANT-008` now pins the whole `authenticated` surface so a missing *or* extra grant goes red.

## Testing

- **199 pgTAP assertions across 20 files**, green, including #264's own suite
- Two new files: `18_function_execute_grants.sql` (grants + the NULL-guard behaviour) and `19_together_session_partner_scope.sql` (partner scoping, the INSERT/UPDATE bypasses, child-table repointing, the seeder guard)
- `03_scripture_rpcs.sql` and `13_*.sql` gained two setup lines each — they called `scripture_create_session('together', ...)` with unlinked users
- Every policy keeps its existing **name**, so the `policies_are` arrays in `02_rls_policies.sql` need no edit
- `supabase db lint --schema public --level error --fail-on error` clean
- Reviewed adversarially by subagents at each stage; findings drove the INSERT/UPDATE/child-table fixes, the removal of the cleanup DELETE, and the `'none'`/`authenticator` tightening

## Migration numbering — please read

These were originally `20260817000000`/`...0001` and test files `17_`/`18_`, which **collided with #264's `20260817000000_love_note_removals.sql` and `17_love_note_removals.sql`**.

The first migration had already been deployed under `20260817000000`, so when #264 shipped, Supabase would have seen that version as applied and **silently skipped creating the `love_note_removals` table**. Mine are renumbered to `20260818000000`/`...0001` and `18_`/`19_`, and production's recorded versions were corrected. #264's migration, view and table grants are verified intact on a combined `db reset`.

Because of that ordering dependency this is based on #264 and should merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuMS3FQ5dWncB9SUpWaujo
