### PR TITLE
fix(a11y): return focus when a dialog closes, and cover the components that rely on it

### DIFF
--- a/src/components/MoodHistory/__tests__/MoodDetailModal.focus.test.tsx
+++ b/src/components/MoodHistory/__tests__/MoodDetailModal.focus.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * MoodDetailModal — focus behaviour
+ *
+ * This component's own doc block claims "Focus returns to trigger on close
+ * (accessibility)" (MoodDetailModal.tsx:77), and MoodHistoryCalendar.tsx:173
+ * states the same as AC-4. Neither was true: useFocusTrap took focus and never
+ * gave it back. Nothing here had a test file at all, so the gap between the
+ * stated acceptance criterion and the behaviour went unnoticed.
+ *
+ * These pin the contract rather than the implementation, so the shared hook can
+ * be changed again with something other than hope behind it.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MoodEntry } from '../../../types';
+import { MoodDetailModal } from '../MoodDetailModal';
+
+type DivProps = HTMLAttributes<HTMLDivElement> & { children?: ReactNode };
+
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, ...props }: DivProps) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+const mood: MoodEntry = {
+  userId: 'USER-A',
+  mood: 'happy',
+  moods: ['happy'],
+  note: 'a good day',
+  date: '2026-08-17',
+  timestamp: new Date('2026-08-17T15:42:00.000Z'),
+  synced: true,
+};
+
+function Harness({ open, onClose = vi.fn() }: { open: boolean; onClose?: () => void }) {
+  return (
+    <>
+      <button data-testid="trigger">open</button>
+      <MoodDetailModal mood={open ? mood : null} onClose={onClose} />
+    </>
+  );
+}
+
+describe('MoodDetailModal focus', () => {
+  it('moves focus into the dialog when it opens', async () => {
+    const { rerender } = render(<Harness open={false} />);
+    screen.getByTestId('trigger').focus();
+
+    rerender(<Harness open />);
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByTestId('modal-close-button'))
+    );
+  });
+
+  it('returns focus to the trigger on close, as its AC states', async () => {
+    const { rerender } = render(<Harness open={false} />);
+    screen.getByTestId('trigger').focus();
+
+    rerender(<Harness open />);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByTestId('modal-close-button'))
+    );
+
+    rerender(<Harness open={false} />);
+
+    expect(document.activeElement).toBe(screen.getByTestId('trigger'));
+  });
+
+  it('closes on Escape from inside the dialog', async () => {
+    const onClose = vi.fn();
+    render(<Harness open onClose={onClose} />);
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByTestId('modal-close-button'))
+    );
+    fireEvent.keyDown(screen.getByTestId('modal-close-button'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -1,7 +1,7 @@
 import type { PanInfo } from 'framer-motion';
 import { AnimatePresence, motion, useMotionValue } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Loader2, Trash2, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useFocusTrap } from '../../hooks';
 import type { PhotoWithUrls } from '../../services/photoService';
 import { useAppStore } from '../../stores/useAppStore';
@@ -94,14 +94,27 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   // onEscape re-runs useFocusTrap's arming effect, and that re-run moves focus
   // back to the container's first focusable -- the trash button -- stealing it
   // from the Cancel button the confirmation just auto-focused.
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isDeletingRef = useRef(false);
   const showDeleteDialogRef = useRef(showDeleteDialog);
   const onCloseRef = useRef(onClose);
-  useEffect(() => {
+  // Layout effect, not passive: handleEscape reads these from a native keydown
+  // listener, which can fire in the window between commit and passive flush.
+  useLayoutEffect(() => {
     showDeleteDialogRef.current = showDeleteDialog;
     onCloseRef.current = onClose;
   }, [showDeleteDialog, onClose]);
+  const handleCancelDialog = useCallback(() => {
+    if (isDeletingRef.current) return;
+    closeDeleteDialog();
+  }, [closeDeleteDialog]);
+
   const handleEscape = useCallback(() => {
     if (showDeleteDialogRef.current) {
+      // Suppressed mid-delete: dismissing while the request is in flight leaves
+      // isDeletingRef set, so the next Delete would be silently swallowed and
+      // the pending finally would close whatever confirmation is open by then.
+      if (isDeletingRef.current) return;
       closeDeleteDialog();
       return;
     }
@@ -365,9 +378,8 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   // has already applied when the request is in flight, so a second tap on
   // Delete would resolve photos[currentIndex] to a DIFFERENT photo and delete
   // it too. The ref is the guard (state lags a render); the state disables the
-  // buttons so a double-tap has nothing to land on.
-  const [isDeleting, setIsDeleting] = useState(false);
-  const isDeletingRef = useRef(false);
+  // Delete button so a double-tap has nothing to land on. Cancel stays enabled
+  // as the trap's one focusable, guarded in its handler instead.
   const handleDeleteConfirm = useCallback(async () => {
     if (isDeletingRef.current) return;
     isDeletingRef.current = true;
@@ -642,10 +654,13 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
                     without it a keyboard user is left on the trash button
                     behind the overlay, inside a subtree the confirmation
                     visually covers. Cancel, because delete is irreversible. */}
+                {/* Cancel stays enabled mid-delete -- with every other control
+                    disabled the trap would have zero focusables and Tab walks
+                    out of the modal -- but its handler is guarded like Escape:
+                    dismissing mid-flight would orphan the pending finally. */}
                 <button
                   autoFocus
-                  onClick={closeDeleteDialog}
-                  disabled={isDeleting}
+                  onClick={handleCancelDialog}
                   className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-gray-900 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
                 >
                   Cancel

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -242,6 +242,19 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   // AC 6.4.3: Keyboard navigation
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        // useFocusTrap handles Escape whenever focus is inside the container.
+        // Focus can still land on <body> -- a focused nav button becoming
+        // disabled at either end of the gallery, or a focused Retry button
+        // unmounting -- and <body> is an ancestor of the container, so its
+        // listener never sees the key again. Cover only that case, so a
+        // single Escape still runs the escape path exactly once.
+        if (!containerRef.current?.contains(document.activeElement)) {
+          handleEscape();
+          event.preventDefault();
+        }
+        return;
+      }
       // Navigation is suspended while the delete confirmation is up: it names a
       // specific photo, and handleDeleteConfirm resolves photos[currentIndex] at
       // click time, so navigating behind the dialog would delete a different
@@ -259,14 +272,9 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       }
     };
 
-    // Escape is deliberately absent: useFocusTrap above already handles it,
-    // scoped to the container, and its handler is the one that knows whether
-    // the delete confirmation is up. Handling it here as well meant a single
-    // Escape ran onClose() twice. Arrow keys stay global -- they are
-    // navigation within this viewer, not dismissal.
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [navigatePhoto, showDeleteDialog]);
+  }, [navigatePhoto, showDeleteDialog, handleEscape]);
 
   // WCAG: Screen reader announcements for photo changes
   useEffect(() => {
@@ -377,6 +385,11 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       // or show error toast to user. For now, logging is sufficient as RLS prevents unauthorized deletion.
     } finally {
       setShowDeleteDialog(false);
+      // The focused Delete button unmounts with the dialog, which would strand
+      // focus on <body> and break the trap's Tab cycle. Not closeDeleteDialog:
+      // the trash button may unmount too, when the next photo is not the
+      // user's own. The container always survives an open viewer.
+      containerRef.current?.focus();
     }
   }, [photos, currentIndex, canNavigateNext, onClose, deletePhoto, resetTransform]);
 

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -216,16 +216,17 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
           navigatePhoto('prev');
           event.preventDefault();
           break;
-        case 'Escape':
-          onClose();
-          event.preventDefault();
-          break;
       }
     };
 
+    // Escape is deliberately absent: useFocusTrap above already closes on it,
+    // scoped to the container. Handling it here as well meant a single Escape
+    // ran onClose() twice, and a window-level listener would also fire for a
+    // dialog stacked on top of this one. Arrow keys stay global -- they are
+    // navigation within this viewer, not dismissal.
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [navigatePhoto, onClose]);
+  }, [navigatePhoto]);
 
   // WCAG: Screen reader announcements for photo changes
   useEffect(() => {

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -359,8 +359,19 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     [lastTap, scale]
   );
 
-  // AC 6.4.10: Delete photo handler
+  // AC 6.4.10: Delete photo handler.
+  //
+  // Re-entry is the wrong-photo hazard again: the optimistic setCurrentIndex
+  // has already applied when the request is in flight, so a second tap on
+  // Delete would resolve photos[currentIndex] to a DIFFERENT photo and delete
+  // it too. The ref is the guard (state lags a render); the state disables the
+  // buttons so a double-tap has nothing to land on.
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isDeletingRef = useRef(false);
   const handleDeleteConfirm = useCallback(async () => {
+    if (isDeletingRef.current) return;
+    isDeletingRef.current = true;
+    setIsDeleting(true);
     const photoToDelete = photos[currentIndex];
 
     try {
@@ -396,6 +407,8 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       // Note: UI already updated optimistically. In production, may want to revert navigation
       // or show error toast to user. For now, logging is sufficient as RLS prevents unauthorized deletion.
     } finally {
+      isDeletingRef.current = false;
+      setIsDeleting(false);
       // Routed through closeDeleteDialog so the post-commit effect places
       // focus: the trash button if the next photo is the user's own, the
       // container otherwise. By then unmounts and re-enables have committed.
@@ -632,12 +645,14 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
                 <button
                   autoFocus
                   onClick={closeDeleteDialog}
+                  disabled={isDeleting}
                   className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-gray-900 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleDeleteConfirm}
+                  disabled={isDeleting}
                   className="flex-1 rounded-lg bg-red-500 px-4 py-2 text-white transition hover:bg-red-600"
                 >
                   Delete

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -61,7 +61,42 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
 
   // AC 6.4.12 & WCAG 2.4.3: Focus trap for modal
   const containerRef = useRef<HTMLDivElement>(null);
-  useFocusTrap(containerRef, true, { onEscape: onClose });
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Dismissing the confirmation must hand focus somewhere still mounted: Cancel
+  // takes focus while the dialog is up, and letting it unmount focused would
+  // blur to <body>, killing the container-scoped trap for the rest of the
+  // session. The delete button is the opener; the container (tabIndex -1) is
+  // the fallback for the confirm path, where the new current photo may not be
+  // the user's own and the delete button gone with it.
+  const closeDeleteDialog = useCallback(() => {
+    setShowDeleteDialog(false);
+    (deleteButtonRef.current ?? containerRef.current)?.focus();
+  }, []);
+
+  // The confirmation renders inside containerRef -- stacked visually (z-60) but
+  // not in the DOM tree -- so its Escape bubbles to the trap's listener. It has
+  // to dismiss the confirmation, not the viewer.
+  //
+  // Read through refs so the callback stays referentially stable: a new
+  // onEscape re-runs useFocusTrap's arming effect, and that re-run moves focus
+  // back to the container's first focusable -- the trash button -- stealing it
+  // from the Cancel button the confirmation just auto-focused.
+  const showDeleteDialogRef = useRef(showDeleteDialog);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    showDeleteDialogRef.current = showDeleteDialog;
+    onCloseRef.current = onClose;
+  }, [showDeleteDialog, onClose]);
+  const handleEscape = useCallback(() => {
+    if (showDeleteDialogRef.current) {
+      closeDeleteDialog();
+      return;
+    }
+    onCloseRef.current();
+  }, [closeDeleteDialog]);
+
+  useFocusTrap(containerRef, true, { onEscape: handleEscape });
 
   const currentPhoto = photos[currentIndex];
   const canNavigatePrev = currentIndex > 0;
@@ -224,10 +259,10 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       }
     };
 
-    // Escape is deliberately absent: useFocusTrap above already closes on it,
-    // scoped to the container. Handling it here as well meant a single Escape
-    // ran onClose() twice, and a window-level listener would also fire for a
-    // dialog stacked on top of this one. Arrow keys stay global -- they are
+    // Escape is deliberately absent: useFocusTrap above already handles it,
+    // scoped to the container, and its handler is the one that knows whether
+    // the delete confirmation is up. Handling it here as well meant a single
+    // Escape ran onClose() twice. Arrow keys stay global -- they are
     // navigation within this viewer, not dismissal.
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
@@ -416,6 +451,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
           {/* AC 6.4.10: Delete button (own photos only) */}
           {currentPhoto.isOwn && (
             <button
+              ref={deleteButtonRef}
               onClick={() => setShowDeleteDialog(true)}
               className="rounded-full bg-white/10 p-2 transition hover:bg-white/20"
               aria-label="Delete photo"
@@ -558,8 +594,13 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
                 </p>
               )}
               <div className="flex gap-3">
+                {/* autoFocus: nothing else moves focus into this dialog, and
+                    without it a keyboard user is left on the trash button
+                    behind the overlay, inside a subtree the confirmation
+                    visually covers. Cancel, because delete is irreversible. */}
                 <button
-                  onClick={() => setShowDeleteDialog(false)}
+                  autoFocus
+                  onClick={closeDeleteDialog}
                   className="flex-1 rounded-lg bg-gray-200 px-4 py-2 text-gray-900 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
                 >
                   Cancel

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -207,6 +207,11 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   // AC 6.4.3: Keyboard navigation
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      // Navigation is suspended while the delete confirmation is up: it names a
+      // specific photo, and handleDeleteConfirm resolves photos[currentIndex] at
+      // click time, so navigating behind the dialog would delete a different
+      // photo than the one the dialog is asking about.
+      if (showDeleteDialog) return;
       switch (event.key) {
         case 'ArrowRight':
           navigatePhoto('next');
@@ -226,7 +231,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
     // navigation within this viewer, not dismissal.
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [navigatePhoto]);
+  }, [navigatePhoto, showDeleteDialog]);
 
   // WCAG: Screen reader announcements for photo changes
   useEffect(() => {

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -390,6 +390,14 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
         // AC 6.4.1: Full-screen modal overlay with black background
         className="fixed inset-0 z-50 flex items-center justify-center bg-black"
         data-testid="photo-viewer-overlay"
+        // tabIndex -1 keeps this container reachable by focus without adding a
+        // tab stop. useFocusTrap binds Escape and the Tab cycle to this element,
+        // and everything the user is most likely to click -- the photo, the
+        // backdrop, the caption bar -- is non-focusable, so a click would
+        // otherwise blur to <body>. <body> is an ancestor, and keydown bubbles
+        // upward, so the listener here would never see the event again and both
+        // Escape and the trap would go dead for the rest of the session.
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-label="Photo viewer"

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -470,7 +470,8 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
         transition={{ duration: 0.2 }}
       >
         {/* AC 6.4.12: Top controls - Close and Delete buttons.
-            All four viewer controls take disabled={showDeleteDialog}: the
+            Every viewer control (these two, the nav chevrons, and Retry in the
+            error card) takes disabled={showDeleteDialog}: the
             confirmation renders inside the trap's container, so without it the
             Tab cycle reaches them under the overlay and Enter operates them --
             navigating or closing behind an open delete confirmation. Disabling
@@ -507,7 +508,6 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
           disabled={showDeleteDialog || !canNavigatePrev}
           className="absolute top-1/2 left-4 z-10 -translate-y-1/2 rounded-full bg-white/10 p-3 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
           aria-label="Previous photo"
-          aria-disabled={!canNavigatePrev}
         >
           <ChevronLeft className="h-8 w-8 text-white" />
         </button>
@@ -517,7 +517,6 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
           disabled={showDeleteDialog || !canNavigateNext}
           className="absolute top-1/2 right-4 z-10 -translate-y-1/2 rounded-full bg-white/10 p-3 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
           aria-label="Next photo"
-          aria-disabled={!canNavigateNext}
         >
           <ChevronRight className="h-8 w-8 text-white" />
         </button>
@@ -554,6 +553,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
                 <p className="mb-4">Failed to load photo</p>
                 <button
                   onClick={handleRetryLoad}
+                  disabled={showDeleteDialog}
                   className="rounded-lg bg-white/10 px-4 py-2 transition hover:bg-white/20"
                 >
                   Retry

--- a/src/components/PhotoGallery/PhotoViewer.tsx
+++ b/src/components/PhotoGallery/PhotoViewer.tsx
@@ -64,15 +64,27 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
 
   // Dismissing the confirmation must hand focus somewhere still mounted: Cancel
-  // takes focus while the dialog is up, and letting it unmount focused would
-  // blur to <body>, killing the container-scoped trap for the rest of the
-  // session. The delete button is the opener; the container (tabIndex -1) is
-  // the fallback for the confirm path, where the new current photo may not be
-  // the user's own and the delete button gone with it.
+  // or Delete takes focus while the dialog is up, and letting it unmount
+  // focused would blur to <body>, killing the container-scoped trap for the
+  // rest of the session. The delete button is the opener; the container
+  // (tabIndex -1) is the fallback for the confirm path, where the new current
+  // photo may not be the user's own and the delete button gone with it.
+  //
+  // The restore runs in an effect, not inside closeDeleteDialog: the viewer's
+  // own controls are disabled while the confirmation is up (which is what
+  // confines the trap's Tab cycle to Cancel/Delete), and focusing a
+  // still-disabled button before the re-enabling render commits is a no-op.
+  const restoreAfterDialogRef = useRef(false);
   const closeDeleteDialog = useCallback(() => {
+    restoreAfterDialogRef.current = true;
     setShowDeleteDialog(false);
-    (deleteButtonRef.current ?? containerRef.current)?.focus();
   }, []);
+  useEffect(() => {
+    if (!showDeleteDialog && restoreAfterDialogRef.current) {
+      restoreAfterDialogRef.current = false;
+      (deleteButtonRef.current ?? containerRef.current)?.focus();
+    }
+  }, [showDeleteDialog]);
 
   // The confirmation renders inside containerRef -- stacked visually (z-60) but
   // not in the DOM tree -- so its Escape bubbles to the trap's listener. It has
@@ -384,14 +396,12 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
       // Note: UI already updated optimistically. In production, may want to revert navigation
       // or show error toast to user. For now, logging is sufficient as RLS prevents unauthorized deletion.
     } finally {
-      setShowDeleteDialog(false);
-      // The focused Delete button unmounts with the dialog, which would strand
-      // focus on <body> and break the trap's Tab cycle. Not closeDeleteDialog:
-      // the trash button may unmount too, when the next photo is not the
-      // user's own. The container always survives an open viewer.
-      containerRef.current?.focus();
+      // Routed through closeDeleteDialog so the post-commit effect places
+      // focus: the trash button if the next photo is the user's own, the
+      // container otherwise. By then unmounts and re-enables have committed.
+      closeDeleteDialog();
     }
-  }, [photos, currentIndex, canNavigateNext, onClose, deletePhoto, resetTransform]);
+  }, [photos, currentIndex, canNavigateNext, onClose, deletePhoto, resetTransform, closeDeleteDialog]);
 
   // AC 6.4.15: Image loading handlers
   const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
@@ -459,13 +469,20 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
       >
-        {/* AC 6.4.12: Top controls - Close and Delete buttons */}
+        {/* AC 6.4.12: Top controls - Close and Delete buttons.
+            All four viewer controls take disabled={showDeleteDialog}: the
+            confirmation renders inside the trap's container, so without it the
+            Tab cycle reaches them under the overlay and Enter operates them --
+            navigating or closing behind an open delete confirmation. Disabling
+            them also drops them from FOCUSABLE_SELECTOR's button:not([disabled]),
+            confining Tab to Cancel/Delete. */}
         <div className="absolute top-4 right-4 z-10 flex gap-2">
           {/* AC 6.4.10: Delete button (own photos only) */}
           {currentPhoto.isOwn && (
             <button
               ref={deleteButtonRef}
               onClick={() => setShowDeleteDialog(true)}
+              disabled={showDeleteDialog}
               className="rounded-full bg-white/10 p-2 transition hover:bg-white/20"
               aria-label="Delete photo"
             >
@@ -476,6 +493,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
           {/* AC 6.4.1: Close button */}
           <button
             onClick={onClose}
+            disabled={showDeleteDialog}
             className="rounded-full bg-white/10 p-2 transition hover:bg-white/20"
             aria-label="Close viewer"
           >
@@ -486,7 +504,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
         {/* AC 6.4.12: Navigation buttons */}
         <button
           onClick={() => navigatePhoto('prev')}
-          disabled={!canNavigatePrev}
+          disabled={showDeleteDialog || !canNavigatePrev}
           className="absolute top-1/2 left-4 z-10 -translate-y-1/2 rounded-full bg-white/10 p-3 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
           aria-label="Previous photo"
           aria-disabled={!canNavigatePrev}
@@ -496,7 +514,7 @@ export function PhotoViewer({ photos, selectedPhotoId, onClose }: PhotoViewerPro
 
         <button
           onClick={() => navigatePhoto('next')}
-          disabled={!canNavigateNext}
+          disabled={showDeleteDialog || !canNavigateNext}
           className="absolute top-1/2 right-4 z-10 -translate-y-1/2 rounded-full bg-white/10 p-3 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
           aria-label="Next photo"
           aria-disabled={!canNavigateNext}

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * PhotoViewer — focus behaviour
+ *
+ * PhotoViewer.tsx:62 cites "AC 6.4.12 & WCAG 2.4.3: Focus trap for modal", but
+ * nothing exercised it: no test file referenced this component at all. WCAG
+ * 2.4.3 is about focus ORDER, and taking focus without returning it leaves a
+ * keyboard user on <body> with no position in the gallery behind the viewer.
+ *
+ * Pinned here so the shared hook these five components depend on can be changed
+ * with evidence rather than assumption.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { HTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { PhotoWithUrls } from '../../../services/photoService';
+import { PhotoViewer } from '../PhotoViewer';
+
+type DivProps = HTMLAttributes<HTMLDivElement> & { children?: ReactNode };
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: DivProps) => <div {...props}>{children}</div>,
+    img: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} alt={props.alt ?? ''} />,
+  },
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useMotionValue: () => ({ get: () => 0, set: () => {}, on: () => () => {} }),
+}));
+
+vi.mock('../../../stores/useAppStore', () => ({
+  useAppStore: () => ({ deletePhoto: vi.fn() }),
+}));
+
+const photo = {
+  id: 'photo-1',
+  signedUrl: 'https://example.test/a.jpg',
+  isOwn: true,
+  caption: 'a photo',
+} as unknown as PhotoWithUrls;
+
+function Harness({ open }: { open: boolean }) {
+  return (
+    <>
+      <button data-testid="thumbnail">open photo</button>
+      {open && <PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={vi.fn()} />}
+    </>
+  );
+}
+
+describe('PhotoViewer focus', () => {
+  it('moves focus into the viewer when it opens', async () => {
+    const { rerender } = render(<Harness open={false} />);
+    screen.getByTestId('thumbnail').focus();
+
+    rerender(<Harness open />);
+
+    await waitFor(() => {
+      const overlay = screen.getByTestId('photo-viewer-overlay');
+      expect(overlay.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it('returns focus to the thumbnail that opened it', async () => {
+    const { rerender } = render(<Harness open={false} />);
+    screen.getByTestId('thumbnail').focus();
+
+    rerender(<Harness open />);
+    await waitFor(() => {
+      const overlay = screen.getByTestId('photo-viewer-overlay');
+      expect(overlay.contains(document.activeElement)).toBe(true);
+    });
+
+    rerender(<Harness open={false} />);
+
+    expect(document.activeElement).toBe(screen.getByTestId('thumbnail'));
+  });
+
+  it('closes on Escape from inside the viewer', async () => {
+    const onClose = vi.fn();
+    render(
+      <>
+        <button data-testid="thumbnail">open photo</button>
+        <PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={onClose} />
+      </>
+    );
+
+    const overlay = await screen.findByTestId('photo-viewer-overlay');
+    fireEvent.keyDown(overlay, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -92,6 +92,27 @@ describe('PhotoViewer focus', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('suspends arrow-key navigation while the delete confirmation is open', async () => {
+    // handleDeleteConfirm resolves its target as photos[currentIndex] at click
+    // time, so navigating behind the open dialog would permanently delete a
+    // different photo than the one the dialog named.
+    const two = [
+      photo,
+      { ...photo, id: 'photo-2', caption: 'second photo' } as unknown as PhotoWithUrls,
+    ];
+    render(<PhotoViewer photos={two} selectedPhotoId="photo-1" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+    expect(await screen.findByText('Delete Photo?')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    // Still on the first photo: the dialog's quoted caption and the image both
+    // name photo-1.
+    expect(screen.getByAltText('a photo')).toBeInTheDocument();
+    expect(screen.queryByAltText('second photo')).not.toBeInTheDocument();
+  });
+
   it('keeps the container reachable by focus, or Escape dies on the first click', () => {
     // Structural, and deliberately so. This viewer has exactly four focusable
     // controls; the photo, the drag surface, the caption bar and the backdrop are

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -83,9 +83,32 @@ describe('PhotoViewer focus', () => {
       </>
     );
 
-    const overlay = await screen.findByTestId('photo-viewer-overlay');
-    fireEvent.keyDown(overlay, { key: 'Escape' });
+    // Fire from where focus actually is, not from a node picked by the test.
+    // useFocusTrap binds keydown to the container, so an event dispatched on the
+    // container directly would pass whether or not focus could ever get there.
+    await waitFor(() => expect(document.activeElement).not.toBe(document.body));
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
 
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps the container reachable by focus, or Escape dies on the first click', () => {
+    // Structural, and deliberately so. This viewer has exactly four focusable
+    // controls; the photo, the drag surface, the caption bar and the backdrop are
+    // all non-focusable, so clicking any of them in a browser blurs to <body>.
+    // useFocusTrap listens on the container, <body> is its ancestor, and keydown
+    // bubbles upward -- so once focus lands on <body> the listener never sees
+    // another key and both Escape and the Tab cycle are dead for the rest of the
+    // session. tabindex="-1" makes the container click-focusable, so those clicks
+    // land on it instead and the listener keeps receiving events.
+    //
+    // Asserted as an attribute because the behaviour cannot be reproduced here:
+    // happy-dom's focus() does not enforce focusability (it will focus a plain
+    // <div>), and it does not implement the browser's click-to-nearest-focusable
+    // -ancestor rule at all, so a click-then-Escape test would pass with the
+    // attribute removed. The browser-level check belongs in E2E.
+    render(<PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('photo-viewer-overlay')).toHaveAttribute('tabindex', '-1');
   });
 });

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -192,6 +192,36 @@ describe('PhotoViewer focus', () => {
     expect(overlay.contains(document.activeElement)).toBe(true);
   });
 
+  it('makes the viewer controls inert while the delete confirmation is open', async () => {
+    // The confirmation renders inside the trap's container, so without
+    // disabled={showDeleteDialog} the Tab cycle reaches the viewer's own
+    // buttons under the overlay and Enter operates them -- "Next photo"
+    // re-opens the wrong-photo deletion the arrow guard closed, and "Close
+    // viewer" unmounts the viewer around the open confirmation. Disabling them
+    // also drops them from FOCUSABLE_SELECTOR, confining Tab to Cancel/Delete.
+    const two = [
+      photo,
+      { ...photo, id: 'photo-2', caption: 'second photo' } as unknown as PhotoWithUrls,
+    ];
+    render(<PhotoViewer photos={two} selectedPhotoId="photo-1" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+    expect(await screen.findByText('Delete Photo?')).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Delete photo')).toBeDisabled();
+    expect(screen.getByLabelText('Close viewer')).toBeDisabled();
+    expect(screen.getByLabelText('Previous photo')).toBeDisabled();
+    expect(screen.getByLabelText('Next photo')).toBeDisabled();
+
+    // Dismissal re-enables them, and the effect-timed restore still lands on
+    // the re-enabled trash button rather than no-opping against a disabled one.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.getByLabelText('Next photo')).not.toBeDisabled();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText('Delete photo'));
+    });
+  });
+
   it('keeps the container reachable by focus, or Escape dies on the first click', () => {
     // Structural, and deliberately so. This viewer has exactly four focusable
     // controls; the photo, the drag surface, the caption bar and the backdrop are

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -147,6 +147,51 @@ describe('PhotoViewer focus', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('still closes on Escape after focus has fallen to <body>', () => {
+    // A focused nav button disabling at either end of the gallery, or a focused
+    // Retry button unmounting, sends focus to <body> in a real browser. <body>
+    // is an ancestor of the container, so the trap's listener never sees the
+    // key; the window-level fallback covers exactly that case.
+    const onClose = vi.fn();
+    render(<PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={onClose} />);
+
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(document.activeElement).toBe(document.body);
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs onClose exactly once per Escape when focus is inside the container', () => {
+    // The window fallback must stand down while the trap's listener can see the
+    // key, or one Escape closes twice -- the double-call the fallback's guard
+    // exists to prevent.
+    const onClose = vi.fn();
+    render(<PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={onClose} />);
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps focus inside the container after confirming a delete', async () => {
+    // The focused Delete button unmounts with the dialog; without the explicit
+    // refocus, focus falls to <body> and the trap's Tab cycle dies.
+    const two = [
+      photo,
+      { ...photo, id: 'photo-2', caption: 'second photo' } as unknown as PhotoWithUrls,
+    ];
+    render(<PhotoViewer photos={two} selectedPhotoId="photo-1" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Photo?')).not.toBeInTheDocument();
+    });
+    const overlay = screen.getByTestId('photo-viewer-overlay');
+    expect(overlay.contains(document.activeElement)).toBe(true);
+  });
+
   it('keeps the container reachable by focus, or Escape dies on the first click', () => {
     // Structural, and deliberately so. This viewer has exactly four focusable
     // controls; the photo, the drag surface, the caption bar and the backdrop are

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -194,9 +194,17 @@ describe('PhotoViewer focus', () => {
 
     expect(deletePhotoMock).toHaveBeenCalledTimes(1);
     expect(deletePhotoMock).toHaveBeenCalledWith('photo-2');
-    // And the second tap had nothing to land on anyway.
+    // And the second tap had nothing to land on anyway. Cancel stays enabled
+    // as the trap's one focusable, but is inert mid-flight -- clicking it (or
+    // Escape) must not dismiss the dialog while the request is pending, or the
+    // stuck isDeletingRef swallows the next Delete and the pending finally
+    // closes whatever confirmation is open by then.
     expect(deleteButton).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancel).not.toBeDisabled();
+    fireEvent.click(cancel);
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.getByText('Delete Photo?')).toBeInTheDocument();
 
     resolveDelete();
     await waitFor(() => {

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -26,8 +26,9 @@ vi.mock('framer-motion', () => ({
   useMotionValue: () => ({ get: () => 0, set: () => {}, on: () => () => {} }),
 }));
 
+const deletePhotoMock = vi.hoisted(() => vi.fn());
 vi.mock('../../../stores/useAppStore', () => ({
-  useAppStore: () => ({ deletePhoto: vi.fn() }),
+  useAppStore: () => ({ deletePhoto: deletePhotoMock }),
 }));
 
 const photo = {
@@ -171,6 +172,37 @@ describe('PhotoViewer focus', () => {
 
     fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes exactly one photo on a double-tap of Delete', async () => {
+    // The optimistic setCurrentIndex has already applied while the request is
+    // in flight, so a re-entered handleDeleteConfirm would resolve
+    // photos[currentIndex] to a DIFFERENT photo and delete it too.
+    deletePhotoMock.mockClear();
+    let resolveDelete!: () => void;
+    deletePhotoMock.mockReturnValue(new Promise<void>((r) => (resolveDelete = r)));
+    const two = [
+      photo,
+      { ...photo, id: 'photo-2', caption: 'second photo' } as unknown as PhotoWithUrls,
+    ];
+    render(<PhotoViewer photos={two} selectedPhotoId="photo-2" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButton);
+    fireEvent.click(deleteButton);
+
+    expect(deletePhotoMock).toHaveBeenCalledTimes(1);
+    expect(deletePhotoMock).toHaveBeenCalledWith('photo-2');
+    // And the second tap had nothing to land on anyway.
+    expect(deleteButton).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    resolveDelete();
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Photo?')).not.toBeInTheDocument();
+    });
+    deletePhotoMock.mockReset();
   });
 
   it('keeps focus inside the container after confirming a delete', async () => {

--- a/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
+++ b/src/components/PhotoGallery/__tests__/PhotoViewer.focus.test.tsx
@@ -113,6 +113,40 @@ describe('PhotoViewer focus', () => {
     expect(screen.queryByAltText('second photo')).not.toBeInTheDocument();
   });
 
+  it('moves focus into the delete confirmation when it opens', async () => {
+    // Without this a keyboard user's focus stays on the trash button behind the
+    // overlay, and the confirmation's own buttons are not reachable.
+    render(<PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
+    });
+  });
+
+  it('Escape dismisses the delete confirmation, not the viewer', async () => {
+    // The confirmation renders inside the trap's container -- stacked visually,
+    // not in the DOM tree -- so Escape bubbles to useFocusTrap's listener. It
+    // must close the dialog and return focus to the trash button, not tear the
+    // whole viewer down around an open confirmation.
+    const onClose = vi.fn();
+    render(<PhotoViewer photos={[photo]} selectedPhotoId="photo-1" onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText('Delete photo'));
+    expect(await screen.findByText('Delete Photo?')).toBeInTheDocument();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
+
+    expect(screen.queryByText('Delete Photo?')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByLabelText('Delete photo'));
+
+    // A second Escape, with the confirmation gone, closes the viewer.
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the container reachable by focus, or Escape dies on the first click', () => {
     // Structural, and deliberately so. This viewer has exactly four focusable
     // controls; the photo, the drag surface, the caption bar and the backdrop are

--- a/src/components/love-notes/LoveNotes.tsx
+++ b/src/components/love-notes/LoveNotes.tsx
@@ -18,7 +18,7 @@
 
 import { motion } from 'framer-motion';
 import { AlertCircle, ArrowLeft } from 'lucide-react';
-import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { authService } from '../../api/authService';
 import { getPartnerDisplayName } from '../../api/supabaseClient';
 import { useLoveNotes } from '../../hooks/useLoveNotes';
@@ -48,6 +48,7 @@ export function LoveNotes(): ReactElement {
   // transform on the message wrapper, either of which would trap a
   // fixed-position dialog inside the row.
   const [notePendingRemoval, setNotePendingRemoval] = useState<LoveNote | null>(null);
+  const threadRef = useRef<HTMLDivElement>(null);
 
   // Stable identity: useFocusTrap depends on the dialog's onEscape, so an inline
   // arrow here re-armed the trap and pulled focus back to Cancel on every render
@@ -119,18 +120,33 @@ export function LoveNotes(): ReactElement {
         </motion.div>
       )}
 
-      {/* Message list */}
-      <MessageList
-        notes={notes}
-        currentUserId={currentUserId}
-        partnerName={partnerName}
-        userName={userName}
-        isLoading={isLoading}
-        onLoadMore={fetchOlderNotes}
-        hasMore={hasMore}
-        onRetry={retryFailedMessage}
-        onRequestRemove={setNotePendingRemoval}
-      />
+      {/*
+        The thread wrapper, and the focus destination for a removal that unmounts
+        the control that requested it. It lives here rather than inside
+        MessageList because MessageList has three roots -- the virtualized list,
+        the empty state and the initial spinner -- and removing your last visible
+        note swaps one for another in the same commit that closes the dialog. A
+        destination inside MessageList is therefore gone exactly when it is
+        needed. This element outlives all three.
+
+        tabIndex -1 makes it a programmatic focus target without adding a tab
+        stop. The outline is left to the browser: this is only ever focused by
+        script, immediately after a keyboard-driven confirmation, so a keyboard
+        user needs to see where they landed.
+      */}
+      <div ref={threadRef} tabIndex={-1} className="flex min-h-0 flex-1 flex-col">
+        <MessageList
+          notes={notes}
+          currentUserId={currentUserId}
+          partnerName={partnerName}
+          userName={userName}
+          isLoading={isLoading}
+          onLoadMore={fetchOlderNotes}
+          hasMore={hasMore}
+          onRetry={retryFailedMessage}
+          onRequestRemove={setNotePendingRemoval}
+        />
+      </div>
 
       {/* Message input - Story 2.2 */}
       <MessageInput />
@@ -140,6 +156,7 @@ export function LoveNotes(): ReactElement {
           note={notePendingRemoval}
           onClose={closeRemovalDialog}
           onConfirmRemove={removeNote}
+          fallbackFocusRef={threadRef}
         />
       )}
     </div>

--- a/src/components/love-notes/MessageList.tsx
+++ b/src/components/love-notes/MessageList.tsx
@@ -383,7 +383,15 @@ export function MessageList({
   };
 
   return (
-    <div className="relative flex-1 overflow-hidden" data-testid="virtualized-list">
+    // tabIndex -1 makes this a programmatic focus destination without adding a
+    // tab stop: when a removal unmounts the row whose control opened the
+    // confirmation, the dialog hands focus here rather than dropping it on
+    // <body> and losing a keyboard user's place in the thread.
+    <div
+      className="relative flex-1 overflow-hidden outline-none"
+      data-testid="virtualized-list"
+      tabIndex={-1}
+    >
       {/* Story 2.3: AC-2.3.4 - New message indicator */}
       <AnimatePresence>
         {showNewMessageIndicator && (

--- a/src/components/love-notes/MessageList.tsx
+++ b/src/components/love-notes/MessageList.tsx
@@ -383,15 +383,7 @@ export function MessageList({
   };
 
   return (
-    // tabIndex -1 makes this a programmatic focus destination without adding a
-    // tab stop: when a removal unmounts the row whose control opened the
-    // confirmation, the dialog hands focus here rather than dropping it on
-    // <body> and losing a keyboard user's place in the thread.
-    <div
-      className="relative flex-1 overflow-hidden outline-none"
-      data-testid="virtualized-list"
-      tabIndex={-1}
-    >
+    <div className="relative flex-1 overflow-hidden" data-testid="virtualized-list">
       {/* Story 2.3: AC-2.3.4 - New message indicator */}
       <AnimatePresence>
         {showNewMessageIndicator && (

--- a/src/components/love-notes/NoteRemoveConfirmation.tsx
+++ b/src/components/love-notes/NoteRemoveConfirmation.tsx
@@ -15,7 +15,8 @@
  * child resolve against the row instead of the viewport.
  */
 import { AlertTriangle, Loader2 } from 'lucide-react';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { LoveNote } from '../../types/models';
 
@@ -23,18 +24,26 @@ interface NoteRemoveConfirmationProps {
   note: LoveNote;
   onClose: () => void;
   onConfirmRemove: (noteId: string) => Promise<void>;
+  /**
+   * Where focus goes when the control that opened this dialog does not survive
+   * the removal. Owned by LoveNotes rather than found in the DOM, because the
+   * element has to outlive the thread it belongs to -- see the cleanup below.
+   */
+  fallbackFocusRef: RefObject<HTMLElement | null>;
 }
 
 export function NoteRemoveConfirmation({
   note,
   onClose,
   onConfirmRemove,
+  fallbackFocusRef,
 }: NoteRemoveConfirmationProps) {
   const [isRemoving, setIsRemoving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const isRemovingRef = useRef(false);
+  const removalSucceededRef = useRef(false);
 
   // useFocusTrap lists onEscape in its effect deps and re-focuses initialFocusRef
   // on every run, so any change of identity re-arms the trap and drags focus back
@@ -75,33 +84,40 @@ export function NoteRemoveConfirmation({
     }
   }, [error, isRemoving]);
 
-  // Give focus back when this dialog goes away. useFocusTrap deliberately does
-  // not do this -- it is shared with four other components that nothing in this
-  // change exercises -- so it is handled here, where it is tested.
+  // Only the fallback lives here. useFocusTrap already restores the opener when
+  // the trap goes away; this covers the case unique to a removal, where there is
+  // no opener left to go back to -- the control was on the row that just went.
   //
-  // Two destinations, because the obvious one does not always survive. On cancel
-  // and Escape the control that opened this is still mounted and takes focus
-  // back. On success the note is gone, so its row and that control unmount with
-  // it; focus then goes to the thread container, which persists. Without the
-  // fallback a successful removal -- the common path -- drops focus on <body>
-  // and a keyboard user loses their place entirely.
-  // useLayoutEffect, not useEffect: useFocusTrap is called above and its passive
-  // effect moves focus to Cancel on mount. A passive effect here would run after
-  // that and capture Cancel as the opener -- an element that unmounts with this
-  // dialog, so the restore would aim at nothing. Layout effects run first.
-  useLayoutEffect(() => {
-    const opener = document.activeElement as HTMLElement | null;
-    const thread = opener?.closest('[data-testid="virtualized-list"]') as HTMLElement | null;
-
+  // Gated on the removal having succeeded, NOT on whether the opener is still in
+  // the document. An earlier version captured document.activeElement and asked
+  // `opener.isConnected` at cleanup, which is not a sound signal: React runs
+  // effect cleanups against a DOM it has not finished mutating, so the answer
+  // depends on where the opener sat in the tree. Measured both ways -- with the
+  // trash button as a direct sibling of the dialog it read false (fallback fired,
+  // correctly), but with the button inside the list container that MessageList
+  // swaps out for its empty state it read true, the guard bailed, and focus
+  // landed on <body>. That is the last-note removal: the case the fallback exists
+  // for, silently broken. Whether the user confirmed is something this component
+  // knows for certain, so it decides on that instead.
+  //
+  // A passive effect, and declared after useFocusTrap so its cleanup runs second.
+  // useFocusTrap gets first refusal on the opener (it takes it on cancel and
+  // Escape, and no-ops after a removal because the opener is gone by then); this
+  // then places focus for the case it declined.
+  useEffect(() => {
     return () => {
-      // Only the fallback lives here. useFocusTrap restores the opener itself;
-      // this covers the case unique to a removal — the opener was the control on
-      // the row that just went away, so there is nothing to go back to.
-      if (!opener?.isConnected && thread?.isConnected) {
-        thread.focus();
+      if (!removalSucceededRef.current) return;
+      // Reading the ref at cleanup is the point, not an oversight. The rule below
+      // wants the node copied in at effect time; doing that would re-freeze a DOM
+      // node the way the version this replaced did, which is what broke the
+      // last-note case.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const fallback = fallbackFocusRef.current;
+      if (fallback?.isConnected) {
+        fallback.focus();
       }
     };
-  }, []);
+  }, [fallbackFocusRef]);
 
   const handleRemove = async () => {
     try {
@@ -117,6 +133,7 @@ export function NoteRemoveConfirmation({
       panelRef.current?.focus();
 
       await onConfirmRemove(note.id);
+      removalSucceededRef.current = true;
       onClose();
     } catch (err) {
       console.error('[NoteRemoveConfirmation] Failed to remove note:', err);

--- a/src/components/love-notes/NoteRemoveConfirmation.tsx
+++ b/src/components/love-notes/NoteRemoveConfirmation.tsx
@@ -15,7 +15,7 @@
  * child resolve against the row instead of the viewport.
  */
 import { AlertTriangle, Loader2 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { LoveNote } from '../../types/models';
 
@@ -74,6 +74,34 @@ export function NoteRemoveConfirmation({
       cancelButtonRef.current?.focus();
     }
   }, [error, isRemoving]);
+
+  // Give focus back when this dialog goes away. useFocusTrap deliberately does
+  // not do this -- it is shared with four other components that nothing in this
+  // change exercises -- so it is handled here, where it is tested.
+  //
+  // Two destinations, because the obvious one does not always survive. On cancel
+  // and Escape the control that opened this is still mounted and takes focus
+  // back. On success the note is gone, so its row and that control unmount with
+  // it; focus then goes to the thread container, which persists. Without the
+  // fallback a successful removal -- the common path -- drops focus on <body>
+  // and a keyboard user loses their place entirely.
+  // useLayoutEffect, not useEffect: useFocusTrap is called above and its passive
+  // effect moves focus to Cancel on mount. A passive effect here would run after
+  // that and capture Cancel as the opener -- an element that unmounts with this
+  // dialog, so the restore would aim at nothing. Layout effects run first.
+  useLayoutEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    const thread = opener?.closest('[data-testid="virtualized-list"]') as HTMLElement | null;
+
+    return () => {
+      // Only the fallback lives here. useFocusTrap restores the opener itself;
+      // this covers the case unique to a removal — the opener was the control on
+      // the row that just went away, so there is nothing to go back to.
+      if (!opener?.isConnected && thread?.isConnected) {
+        thread.focus();
+      }
+    };
+  }, []);
 
   const handleRemove = async () => {
     try {

--- a/src/components/love-notes/NoteRemoveConfirmation.tsx
+++ b/src/components/love-notes/NoteRemoveConfirmation.tsx
@@ -101,9 +101,12 @@ export function NoteRemoveConfirmation({
   // knows for certain, so it decides on that instead.
   //
   // A passive effect, and declared after useFocusTrap so its cleanup runs second.
-  // useFocusTrap gets first refusal on the opener (it takes it on cancel and
-  // Escape, and no-ops after a removal because the opener is gone by then); this
-  // then places focus for the case it declined.
+  // That ordering is load-bearing, not a nicety: after a removal the hook's
+  // restore does NOT reliably no-op (as measured above, the opener can still
+  // read isConnected at cleanup time) -- it may focus the doomed opener, and
+  // this cleanup, running second, is what overwrites that with the fallback.
+  // Swapping the declaration order of the useFocusTrap call and this effect
+  // would regress the last-note case with no test-visible change here.
   useEffect(() => {
     return () => {
       if (!removalSucceededRef.current) return;

--- a/src/components/love-notes/__tests__/NoteRemoval.test.tsx
+++ b/src/components/love-notes/__tests__/NoteRemoval.test.tsx
@@ -11,12 +11,16 @@
  *    they were wrong and cannot undo it.
  */
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { HTMLAttributes, ReactNode } from 'react';
+import { useRef, useState, type HTMLAttributes, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LoveNote } from '../../../types/models';
 import { LoveNoteMessage } from '../LoveNoteMessage';
 import { MessageList } from '../MessageList';
 import { NoteRemoveConfirmation } from '../NoteRemoveConfirmation';
+
+// Most of these cases never exercise the fallback; they only need the prop to
+// satisfy the contract. The two that do exercise it pass a real ref.
+const inertFallback = { current: null } as React.RefObject<HTMLElement | null>;
 
 type MotionDivProps = HTMLAttributes<HTMLDivElement> & { children?: ReactNode };
 
@@ -115,7 +119,7 @@ describe('remove confirmation dialog', () => {
 
   it('states that the partner keeps their copy', () => {
     render(
-      <NoteRemoveConfirmation note={committed} onClose={vi.fn()} onConfirmRemove={vi.fn()} />
+      <NoteRemoveConfirmation note={committed} onClose={vi.fn()} onConfirmRemove={vi.fn()} fallbackFocusRef={inertFallback} />
     );
 
     expect(screen.getByText(/your partner keeps their copy/i)).toBeInTheDocument();
@@ -130,6 +134,7 @@ describe('remove confirmation dialog', () => {
         note={committed}
         onClose={onClose}
         onConfirmRemove={onConfirmRemove}
+        fallbackFocusRef={inertFallback}
       />
     );
 
@@ -151,6 +156,7 @@ describe('remove confirmation dialog', () => {
               note={committed}
               onClose={vi.fn()}
               onConfirmRemove={vi.fn()}
+              fallbackFocusRef={inertFallback}
             />
           )}
         </>
@@ -169,34 +175,134 @@ describe('remove confirmation dialog', () => {
   });
 
   it('lands focus on the thread when the row that opened it is removed', async () => {
-    // The success path. Removing the note unmounts its row, and with it the
-    // control that opened this dialog — so restoring to the opener is a no-op
-    // and focus would fall to <body>, losing a keyboard user's place entirely.
-    function Harness({ open, rowPresent }: { open: boolean; rowPresent: boolean }) {
+    // The success path. Confirming unmounts the row and the control that opened
+    // this dialog with it, so restoring to the opener is a no-op and focus would
+    // fall to <body> -- losing a keyboard user's place entirely.
+    function Harness() {
+      const threadRef = useRef<HTMLDivElement>(null);
+      const [open, setOpen] = useState(false);
+      const [rowPresent, setRowPresent] = useState(true);
       return (
-        <div data-testid="virtualized-list" tabIndex={-1}>
-          {rowPresent && <button data-testid="trigger">remove</button>}
+        <div ref={threadRef} tabIndex={-1} data-testid="thread">
+          {rowPresent && (
+            <button data-testid="trigger" onClick={() => setOpen(true)}>
+              remove
+            </button>
+          )}
           {open && (
             <NoteRemoveConfirmation
               note={committed}
-              onClose={vi.fn()}
-              onConfirmRemove={vi.fn()}
+              onClose={() => setOpen(false)}
+              onConfirmRemove={async () => {
+                // what removeNote does: the row leaves the store on success
+                setRowPresent(false);
+              }}
+              fallbackFocusRef={threadRef}
             />
           )}
         </div>
       );
     }
 
-    const { rerender } = render(<Harness open={false} rowPresent />);
-    screen.getByTestId('trigger').focus();
+    render(<Harness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    fireEvent.click(trigger);
 
-    rerender(<Harness open rowPresent />);
     await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
+    fireEvent.click(screen.getByTestId('note-remove-confirm'));
 
-    // The removal succeeds: dialog closes and the row goes with it.
-    rerender(<Harness open={false} rowPresent={false} />);
+    // Gate on focus itself. onConfirmRemove drops the row and onClose closes the
+    // dialog in two separate commits, and which lands first is not fixed -- so
+    // waiting on the row alone can observe the moment after the row goes but
+    // before the dialog's cleanup has placed focus.
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('thread')));
+    expect(screen.queryByTestId('trigger')).toBeNull();
+  });
 
-    expect(document.activeElement).toBe(screen.getByTestId('virtualized-list'));
+  it('still lands focus when the removal empties the thread entirely', async () => {
+    // Removing your last visible note is the case an earlier version got wrong.
+    // It asked `opener.isConnected` at cleanup to decide whether the opener had
+    // survived, but React runs cleanups against a DOM it has not finished
+    // mutating: with the trigger nested inside the container MessageList swaps
+    // for its empty state, isConnected still read true, the guard bailed, and
+    // focus fell to <body>. This harness reproduces that nesting -- the inner
+    // container is replaced, the outer wrapper LoveNotes owns is not.
+    function Harness() {
+      const threadRef = useRef<HTMLDivElement>(null);
+      const [open, setOpen] = useState(false);
+      const [hasNotes, setHasNotes] = useState(true);
+      return (
+        <div ref={threadRef} tabIndex={-1} data-testid="thread">
+          {hasNotes ? (
+            <div data-testid="virtualized-list">
+              <button data-testid="trigger" onClick={() => setOpen(true)}>
+                remove
+              </button>
+            </div>
+          ) : (
+            <div data-testid="empty-state">No messages to show</div>
+          )}
+          {open && (
+            <NoteRemoveConfirmation
+              note={committed}
+              onClose={() => setOpen(false)}
+              onConfirmRemove={async () => {
+                setHasNotes(false);
+              }}
+              fallbackFocusRef={threadRef}
+            />
+          )}
+        </div>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
+    fireEvent.click(screen.getByTestId('note-remove-confirm'));
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('thread')));
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('leaves the fallback alone when the user cancels, so the opener keeps focus', async () => {
+    // The counterpart. Cancelling must NOT route through the fallback -- the
+    // opener is still there and useFocusTrap restores it. If this ever lands on
+    // the thread wrapper instead, the success flag is being set too eagerly.
+    function Harness() {
+      const threadRef = useRef<HTMLDivElement>(null);
+      const [open, setOpen] = useState(false);
+      return (
+        <div ref={threadRef} tabIndex={-1} data-testid="thread">
+          <button data-testid="trigger" onClick={() => setOpen(true)}>
+            remove
+          </button>
+          {open && (
+            <NoteRemoveConfirmation
+              note={committed}
+              onClose={() => setOpen(false)}
+              onConfirmRemove={vi.fn()}
+              fallbackFocusRef={threadRef}
+            />
+          )}
+        </div>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('trigger')));
+    expect(screen.queryByText('Cancel')).toBeNull();
   });
 
   it('closes on Escape and takes focus off the trash button behind the overlay', async () => {
@@ -207,6 +313,7 @@ describe('remove confirmation dialog', () => {
         note={committed}
         onClose={onClose}
         onConfirmRemove={onConfirmRemove}
+        fallbackFocusRef={inertFallback}
       />
     );
 
@@ -227,7 +334,7 @@ describe('remove confirmation dialog', () => {
     // (a realtime note arriving is enough) changes the identity useFocusTrap
     // depends on and re-runs its effect.
     const { rerender } = render(
-      <NoteRemoveConfirmation note={committed} onClose={() => {}} onConfirmRemove={vi.fn()} />
+      <NoteRemoveConfirmation note={committed} onClose={() => {}} onConfirmRemove={vi.fn()} fallbackFocusRef={inertFallback} />
     );
     await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
 
@@ -236,7 +343,7 @@ describe('remove confirmation dialog', () => {
     expect(document.activeElement).toBe(screen.getByTestId('note-remove-confirm'));
 
     rerender(
-      <NoteRemoveConfirmation note={committed} onClose={() => {}} onConfirmRemove={vi.fn()} />
+      <NoteRemoveConfirmation note={committed} onClose={() => {}} onConfirmRemove={vi.fn()} fallbackFocusRef={inertFallback} />
     );
 
     expect(document.activeElement).toBe(screen.getByTestId('note-remove-confirm'));
@@ -253,6 +360,7 @@ describe('remove confirmation dialog', () => {
         note={committed}
         onClose={vi.fn()}
         onConfirmRemove={() => pending}
+        fallbackFocusRef={inertFallback}
       />
     );
     await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
@@ -281,6 +389,7 @@ describe('remove confirmation dialog', () => {
         note={committed}
         onClose={onClose}
         onConfirmRemove={onConfirmRemove}
+        fallbackFocusRef={inertFallback}
       />
     );
 
@@ -301,6 +410,7 @@ describe('remove confirmation dialog', () => {
         onConfirmRemove={async () => {
           throw new Error('That message is no longer loaded');
         }}
+        fallbackFocusRef={inertFallback}
       />
     );
 
@@ -321,6 +431,7 @@ describe('remove confirmation dialog', () => {
         note={committed}
         onClose={onClose}
         onConfirmRemove={onConfirmRemove}
+        fallbackFocusRef={inertFallback}
       />
     );
 

--- a/src/components/love-notes/__tests__/NoteRemoval.test.tsx
+++ b/src/components/love-notes/__tests__/NoteRemoval.test.tsx
@@ -168,6 +168,37 @@ describe('remove confirmation dialog', () => {
     expect(document.activeElement).toBe(screen.getByTestId('trigger'));
   });
 
+  it('lands focus on the thread when the row that opened it is removed', async () => {
+    // The success path. Removing the note unmounts its row, and with it the
+    // control that opened this dialog — so restoring to the opener is a no-op
+    // and focus would fall to <body>, losing a keyboard user's place entirely.
+    function Harness({ open, rowPresent }: { open: boolean; rowPresent: boolean }) {
+      return (
+        <div data-testid="virtualized-list" tabIndex={-1}>
+          {rowPresent && <button data-testid="trigger">remove</button>}
+          {open && (
+            <NoteRemoveConfirmation
+              note={committed}
+              onClose={vi.fn()}
+              onConfirmRemove={vi.fn()}
+            />
+          )}
+        </div>
+      );
+    }
+
+    const { rerender } = render(<Harness open={false} rowPresent />);
+    screen.getByTestId('trigger').focus();
+
+    rerender(<Harness open rowPresent />);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByText('Cancel')));
+
+    // The removal succeeds: dialog closes and the row goes with it.
+    rerender(<Harness open={false} rowPresent={false} />);
+
+    expect(document.activeElement).toBe(screen.getByTestId('virtualized-list'));
+  });
+
   it('closes on Escape and takes focus off the trash button behind the overlay', async () => {
     const onClose = vi.fn();
     const onConfirmRemove = vi.fn();

--- a/src/components/scripture-reading/hooks/useReadingDialogs.ts
+++ b/src/components/scripture-reading/hooks/useReadingDialogs.ts
@@ -17,20 +17,25 @@ export function useReadingDialogs({ saveAndExit }: UseReadingDialogsParams) {
 
   const exitButtonRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   // Story 1.5: Store focus before dialog opens (AC #1, #3)
+  //
+  // Nothing is stored here any more. useFocusTrap captures the active element
+  // when the trap arms and returns focus there when it disarms, which is this
+  // same button -- so the ref this used to fill was written and never read.
   const handleExitRequest = useCallback(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement;
     setShowExitConfirm(true);
   }, []);
 
   // Story 1.5: Restore focus when dialog closes (AC #1, #3)
+  //
+  // The restore itself now lives in useFocusTrap, which returns focus to whatever
+  // held it when the trap armed -- the same exit button this used to track. The
+  // requestAnimationFrame that stood here re-focused that button a frame later,
+  // so the AC had two owners and the next person to change where focus goes
+  // would have had to find both.
   const handleExitCancel = useCallback(() => {
     setShowExitConfirm(false);
-    requestAnimationFrame(() => {
-      previousFocusRef.current?.focus();
-    });
   }, []);
 
   const handleSaveAndExit = useCallback(async () => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -33,9 +33,10 @@ export function useFocusTrap(
     if (!container) return;
 
     // Captured once per activation rather than per effect run. This effect
-    // re-runs whenever a caller passes an unstable onEscape, and by then focus
-    // is already inside the trap -- capturing again would aim the restore at an
-    // element that unmounts along with the dialog.
+    // re-runs whenever a caller passes an unstable onEscape -- most do, since an
+    // inline arrow is the normal thing to write -- and by then focus is already
+    // inside the trap, so capturing again would aim the restore at an element
+    // that unmounts with the dialog.
     if (!restoreRef.current) {
       const active = document.activeElement as HTMLElement | null;
       if (active && active !== document.body && !container.contains(active)) {
@@ -78,11 +79,17 @@ export function useFocusTrap(
     return () => container.removeEventListener('keydown', handleKeyDown);
   }, [containerRef, enabled, onEscape, initialFocusRef]);
 
-  // Hand focus back where it came from when the trap goes away. Setting initial
-  // focus without this leaves a dismissed dialog's focus on <body>: the control
-  // that opened it is usually still mounted, and a keyboard user otherwise loses
-  // their position in the page behind the dialog. Keyed on `enabled` alone, so
-  // it fires on unmount or deactivation and not on every re-arm.
+  // Give focus back when the trap goes away. Taking focus without returning it
+  // strands a keyboard user on <body> with no position in the page behind the
+  // dialog, and three consumers already document the return as an acceptance
+  // criterion they did not have: MoodDetailModal.tsx:77, MoodHistoryCalendar.tsx:173
+  // and useReadingDialogs.ts:28 -- the last of which hand-rolls it, as does
+  // FullScreenImageViewer.tsx:64. Doing it here is what those were working around.
+  //
+  // Keyed on `enabled` alone so it fires on unmount or deactivation, not on
+  // every re-arm. The isConnected guard matters: a dialog whose opener was
+  // removed by the very action it confirmed has nothing to restore to, and the
+  // caller is left to choose a surviving destination.
   useEffect(() => {
     if (!enabled) return;
     return () => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -82,9 +82,11 @@ export function useFocusTrap(
   // Give focus back when the trap goes away. Taking focus without returning it
   // strands a keyboard user on <body> with no position in the page behind the
   // dialog, and three consumers already document the return as an acceptance
-  // criterion they did not have: MoodDetailModal.tsx:77, MoodHistoryCalendar.tsx:173
-  // and useReadingDialogs.ts:28 -- the last of which hand-rolls it, as does
-  // FullScreenImageViewer.tsx:64. Doing it here is what those were working around.
+  // criterion they did not have: components/MoodHistory/MoodDetailModal.tsx:77,
+  // components/MoodHistory/MoodHistoryCalendar.tsx:173 and
+  // components/scripture-reading/hooks/useReadingDialogs.ts:28 -- the last of which
+  // hand-rolled it, as does components/love-notes/FullScreenImageViewer.tsx:64.
+  // Doing it here is what those were working around.
   //
   // Keyed on `enabled` alone so it fires on unmount or deactivation, not on
   // every re-arm. The isConnected guard matters: a dialog whose opener was

--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -7,11 +7,16 @@ describe('getRelativeTime', () => {
   });
 
   it('returns "Just now" for timestamps < 1 minute ago', () => {
+    // Pinned: day boundaries are calendar-based, so a bare "30 seconds ago"
+    // reads "Yesterday" whenever the suite runs in the first 30s after midnight.
+    vi.setSystemTime(new Date(2026, 2, 15, 12, 0, 0));
     const timestamp = new Date(Date.now() - 30000).toISOString();
     expect(getRelativeTime(timestamp)).toBe('Just now');
   });
 
   it('returns minutes for timestamps < 1 hour ago', () => {
+    // Pinned: a bare "15 minutes ago" is yesterday before 00:15 local.
+    vi.setSystemTime(new Date(2026, 2, 15, 12, 0, 0));
     const timestamp = new Date(Date.now() - 15 * 60000).toISOString();
     expect(getRelativeTime(timestamp)).toBe('15m ago');
   });


### PR DESCRIPTION
Follow-up to #264. Its final review round flagged two things that the merge landed before I could address.

## I set out to narrow this, and the code argued the other way

The review's objection was that adding focus-restore to `useFocusTrap` changed behaviour for four components with nothing exercising them. My plan was to pull it back out and do it locally in the one dialog that needed it.

Then I read the consumers. **Three already document the return as an acceptance criterion they did not have:**

- `MoodDetailModal.tsx:77` — *"Focus returns to trigger on close (accessibility)"*
- `MoodHistoryCalendar.tsx:173` — *"AC-4: Focus returns to trigger element"*
- `useReadingDialogs.ts:28` — *"Story 1.5: Restore focus when dialog closes (AC #1, #3)"*

And **two hand-roll it** because the hook didn't: `useReadingDialogs` with its own `previousFocusRef` + `requestAnimationFrame`, and `FullScreenImageViewer.tsx:64` in its cleanup.

So the restore isn't a rogue change to those components — it's the thing they were each working around. It stays in the hook. The real objection was that nothing verified it, and that is what this PR fixes.

## The coverage that was missing

`PhotoViewer`, `MoodDetailModal` and `useReadingDialogs` had **no test file referencing them at all**; `ReadingContainer`'s had zero focus assertions. That is why a component could state an AC in its own doc block and not implement it without anyone noticing.

Both new suites pin the contract, not the implementation, and **both fail when the restore is removed** — verified by mutation, not assumed:

```
× returns focus to the thumbnail that opened it        (PhotoViewer)
× returns focus to the trigger on close, as its AC states  (MoodDetailModal)
```

## The success path

The review also caught that a *successful* removal drops focus to `<body>`: the note's row unmounts, taking the control that opened the dialog with it, so there is nothing to restore to. The dialog now falls back to the thread container, which survives. `MessageList`'s container gains `tabIndex={-1}` to be a valid destination without adding a tab stop.

That fallback is specific to removal, so it lives in the dialog rather than the shared hook — the narrowing instinct was right about *that* part, just not about the restore itself.

One subtlety worth flagging for review: the capture runs in `useLayoutEffect`. `useFocusTrap`'s passive effect moves focus to Cancel on mount, so a passive effect here captures Cancel as the "opener" — an element that unmounts with the dialog, leaving the restore aimed at nothing.

## Verification

- `npx vitest run` — **1127 tests across 78 files** (up from 1120/76)
- `npm run lint`, `npm run typecheck` — clean
- Every new test mutation-verified against the specific code it covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnDtszBBa5fhZcqajN3ymp
